### PR TITLE
Adding output formatters 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -791,6 +791,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
+name = "csv"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac574ff4d437a7b5ad237ef331c17ccca63c46479e5b5453eb8e10bb99a759fe"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efa2b3d7902f4b634a20cae3c9c4e6209dc4779feb6863329607560143efa70"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "dirs-next"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -822,6 +843,16 @@ name = "dyn-clone"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
+
+[[package]]
+name = "earcutr"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79127ed59a85d7687c409e9978547cffb7dc79675355ed22da6b66fd5f6ead01"
+dependencies = [
+ "itertools 0.11.0",
+ "num-traits",
+]
 
 [[package]]
 name = "either"
@@ -1011,6 +1042,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "float_next_after"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bf7cc16383c4b8d58b9905a8509f02926ce3058053c056376248d958c9df1e8"
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1164,6 +1201,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "geo"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f811f663912a69249fa620dcd2a005db7254529da2d8a0b23942e81f47084501"
+dependencies = [
+ "earcutr",
+ "float_next_after",
+ "geo-types",
+ "geographiclib-rs",
+ "log",
+ "num-traits",
+ "robust",
+ "rstar",
+ "spade",
+]
+
+[[package]]
 name = "geo-types"
 version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1171,7 +1225,17 @@ checksum = "9ff16065e5720f376fbced200a5ae0f47ace85fd70b7e54269790281353b6d61"
 dependencies = [
  "approx",
  "num-traits",
+ "rstar",
  "serde",
+]
+
+[[package]]
+name = "geographiclib-rs"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e5ed84f8089c70234b0a8e0aedb6dc733671612ddc0d37c6066052f9781960"
+dependencies = [
+ "libm",
 ]
 
 [[package]]
@@ -1193,6 +1257,7 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61d25cc15c7e5b86cd8dadea56bb78c46f346d4fb09022e7cbba0839c890d0a1"
 dependencies = [
+ "csv",
  "geo-types",
  "geojson",
  "log",
@@ -1277,6 +1342,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1285,6 +1359,16 @@ dependencies = [
  "ahash",
  "allocator-api2",
  "rayon",
+]
+
+[[package]]
+name = "heapless"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+dependencies = [
+ "hash32",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -2589,6 +2673,7 @@ dependencies = [
  "clap",
  "enum_dispatch",
  "flatgeobuf",
+ "geo",
  "geojson",
  "geozero",
  "httpmock",
@@ -2600,6 +2685,7 @@ dependencies = [
  "strum_macros 0.26.2",
  "tokio",
  "typify",
+ "wkt",
 ]
 
 [[package]]
@@ -2909,6 +2995,23 @@ dependencies = [
  "spin",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "robust"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbf4a6aa5f6d6888f39e980649f3ad6b666acdce1d78e95b8a2cb076e687ae30"
+
+[[package]]
+name = "rstar"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "133315eb94c7b1e8d0cb097e5a710d850263372fd028fff18969de708afc7008"
+dependencies = [
+ "heapless",
+ "num-traits",
+ "smallvec",
 ]
 
 [[package]]
@@ -3296,6 +3399,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "spade"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61addf9117b11d1f5b4bf6fe94242ba25f59d2d4b2080544b771bd647024fd00"
+dependencies = [
+ "hashbrown",
+ "num-traits",
+ "robust",
+ "smallvec",
+]
+
+[[package]]
 name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3309,6 +3424,12 @@ checksum = "743b4dc2cbde11890ccb254a8fc9d537fa41b36da00de2a1c5e9848c9bc42bd7"
 dependencies = [
  "log",
 ]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "stacker"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1180,6 +1180,7 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5d728c1df1fbf328d74151efe6cb0586f79ee813346ea981add69bd22c9241b"
 dependencies = [
+ "geo-types",
  "log",
  "serde",
  "serde_json",
@@ -2588,6 +2589,7 @@ dependencies = [
  "clap",
  "enum_dispatch",
  "flatgeobuf",
+ "geojson",
  "geozero",
  "httpmock",
  "polars",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2685,6 +2685,7 @@ dependencies = [
  "strum_macros 0.26.2",
  "tokio",
  "typify",
+ "wkb",
  "wkt",
 ]
 
@@ -4257,6 +4258,16 @@ checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "wkb"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66c806dac841607a62b0e8babf620fea51429f6ea005545491198fcbfd9004a2"
+dependencies = [
+ "geo-types",
+ "num-traits",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ httpmock = "0.7.0-rc.1"
 geojson={version="0.24.1", optional=true }
 geo = "0.28.0"
 wkt = "0.10.3"
+wkb = "0.7.1"
 
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,9 +21,11 @@ strum = "0.26"
 strum_macros = "0.26"
 enum_dispatch = "0.3"
 flatgeobuf = "4.1.0"
-geozero = {version = "0.12.0", features= []} 
+geozero = {version = "0.12.0", features= ["with-csv","with-geojson"]} 
 httpmock = "0.7.0-rc.1"
 geojson={version="0.24.1", optional=true }
+geo = "0.28.0"
+wkt = "0.10.3"
 
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,9 @@ enum_dispatch = "0.3"
 flatgeobuf = "4.1.0"
 geozero = {version = "0.12.0", features= []} 
 httpmock = "0.7.0-rc.1"
+geojson={version="0.24.1", optional=true }
+
+
+[features]
+default = ["formatters"]
+formatters= ["dep:geojson"]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -5,7 +5,7 @@ use clap::{Args, Parser, Subcommand};
 use enum_dispatch::enum_dispatch;
 use popgetter::{
     data_request_spec::{BBox, DataRequestSpec, MetricSpec, RegionSpec}, 
-    formatters::{CSVFormatter, GeoJSONFormatter, OutputFormatter, OutputGenerator}, Popgetter
+    formatters::{CSVFormatter, GeoJSONFormatter, GeoJSONSeqFormatter, OutputFormatter, OutputGenerator}, Popgetter
 };
 use serde::{Deserialize, Serialize};
 use std::{fs::File, str::FromStr};
@@ -16,6 +16,7 @@ use strum_macros::EnumString;
 #[strum(ascii_case_insensitive)]
 pub enum OutputFormat {
     GeoJSON,
+    GeoJSONSeq,
     Csv,
     GeoParquet,
     FlatGeobuf,
@@ -56,12 +57,15 @@ impl RunCommand for DataCommand {
         let data_request = DataRequestSpec::from(self);
         let mut results = popgetter.get_data_request(&data_request).await?;
 
-        let formatter = match(&self.output_format){
+        let formatter = match &self.output_format{
             OutputFormat::GeoJSON=>{
-                OutputFormatter::GeoJSON(GeoJSONFormatter::default())
+                OutputFormatter::GeoJSON(GeoJSONFormatter)
             },
             OutputFormat::Csv=>{
                 OutputFormatter::Csv(CSVFormatter::default())
+            },
+            OutputFormat::GeoJSONSeq=>{
+                OutputFormatter::GeoJSONSeq(GeoJSONSeqFormatter)
             },
             _=>todo!("output format not implemented")
         };

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -4,11 +4,11 @@ use anyhow::Result;
 use clap::{Args, Parser, Subcommand};
 use enum_dispatch::enum_dispatch;
 use popgetter::{
-    data_request_spec::{BBox, DataRequestSpec, MetricSpec, RegionSpec},
-    Popgetter,
+    data_request_spec::{BBox, DataRequestSpec, MetricSpec, RegionSpec}, 
+    formatters::{CSVFormatter, GeoJSONFormatter, OutputFormatter, OutputGenerator}, Popgetter
 };
 use serde::{Deserialize, Serialize};
-use std::str::FromStr;
+use std::{fs::File, str::FromStr};
 use strum_macros::EnumString;
 
 /// Defines the output formats we are able to produce data in.
@@ -43,16 +43,33 @@ pub struct DataCommand {
     #[arg(short, long)]
     metrics: Option<String>,
     /// Specify output format
-    #[arg(short, long)]
+    #[arg(short='f', long)]
     output_format: OutputFormat,
+
+    #[arg(short='o',long)]
+    output_file: String
 }
 
 impl RunCommand for DataCommand {
     async fn run(&self) -> Result<()> {
         let popgetter = Popgetter::new()?;
         let data_request = DataRequestSpec::from(self);
-        let results = popgetter.get_data_request(&data_request).await?;
+        let mut results = popgetter.get_data_request(&data_request).await?;
+
+        let formatter = match(&self.output_format){
+            OutputFormat::GeoJSON=>{
+                OutputFormatter::GeoJSON(GeoJSONFormatter::default())
+            },
+            OutputFormat::Csv=>{
+                OutputFormatter::Csv(CSVFormatter::default())
+            },
+            _=>todo!("output format not implemented")
+        };
+
         println!("{results:#?}");
+        let mut f = File::create(&self.output_file)?;
+        formatter.save(&mut f,&mut results)?;
+
         Ok(())
     }
 }

--- a/src/data_request_spec.rs
+++ b/src/data_request_spec.rs
@@ -1,7 +1,6 @@
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use std::{
-    any::Any,
     ops::{Index, IndexMut},
     str::FromStr,
 };
@@ -23,12 +22,12 @@ impl DataRequestSpec {
                 MetricSpec::NamedMetric(name) => {
                     metric_requests.push(
                         catalouge
-                            .get_metric_details(&name)
+                            .get_metric_details(name)
                             .with_context(|| "Failed to find metric")?
                             .into(),
                     );
                 }
-                _ => todo!("unsupported metric spec"),
+                MetricSpec::DataProduct(_) => todo!("unsupported metric spec"),
             }
         }
         Ok(metric_requests)

--- a/src/data_request_spec.rs
+++ b/src/data_request_spec.rs
@@ -21,7 +21,7 @@ impl DataRequestSpec {
             match metric_spec {
                 MetricSpec::NamedMetric(name) => {
                     metric_requests.push(
-                        catalouge
+                        catalogue
                             .get_metric_details(name)
                             .with_context(|| "Failed to find metric")?
                             .into(),

--- a/src/formatters.rs
+++ b/src/formatters.rs
@@ -133,8 +133,8 @@ impl OutputGenerator for GeoJSONSeqFormatter {
 
 /// Define what format geometries are represented in
 ///
-/// Wkb: Well known binary
-/// Wkt: Well knoen text
+/// Wkb: Well-known binary
+/// Wkt: Well-known text
 #[derive(Serialize, Deserialize, Debug)]
 pub enum GeoFormat {
     Wkb,

--- a/src/formatters.rs
+++ b/src/formatters.rs
@@ -1,0 +1,76 @@
+use anyhow::Result;
+use enum_dispatch::enum_dispatch;
+use geojson;
+use geojson::{Feature, GeoJson, Geometry, Value};
+use polars::prelude::*;
+use serde::{Deserialize, Serialize};
+use std::io::Cursor;
+use std::{convert::TryFrom, io::Write};
+
+#[enum_dispatch]
+pub trait OutputGenerator {
+    fn format(&self, df: &mut DataFrame) -> Result<String>;
+    fn save(&self, writer: &mut impl Write, df: &mut DataFrame) -> Result<()>;
+}
+
+#[enum_dispatch(OutputGenerator)]
+#[derive(Serialize, Deserialize, Debug)]
+pub enum OutputFormatter {
+    GeoJSON(GeoJSONFormatter),
+    GeoJSONSeq(GeoJSONSeqFormatter),
+    Csv(CSVFormatter),
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct GeoJSONSeqFormatter;
+
+impl OutputGenerator for GeoJSONSeqFormatter {
+    fn format(&self, df: &mut DataFrame) -> Result<String> {
+        Ok("Test".into())
+    }
+
+    fn save(&self, writer: &mut impl Write, df: &mut DataFrame) -> Result<()> {
+        let output = self.format(df)?;
+        Ok(())
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Default)]
+pub struct GeoJSONFormatter;
+
+#[derive(Serialize, Deserialize, Debug)]
+pub enum GeoFormat {
+    Wkb,
+    Wkt,
+}
+
+#[derive(Serialize, Deserialize, Debug, Default)]
+pub struct CSVFormatter {
+    geo_format: Option<GeoFormat>,
+}
+
+impl OutputGenerator for CSVFormatter {
+    fn format(&self, df: &mut DataFrame) -> Result<String> {
+        let mut data: Vec<u8> = vec![0; 200];
+        let mut buff = Cursor::new(&mut data);
+        self.save(&mut buff, df)?;
+
+        Ok(String::from_utf8(data)?)
+    }
+
+    fn save(&self, writer: &mut impl Write, df: &mut DataFrame) -> Result<()> {
+        CsvWriter::new(writer).finish(df)?;
+        Ok(())
+    }
+}
+
+impl OutputGenerator for GeoJSONFormatter {
+    fn format(&self, df: &mut DataFrame) -> Result<String> {
+        Ok("Test".into())
+    }
+
+    fn save(&self, writer: &mut impl Write, df: &mut DataFrame) -> Result<()> {
+        let output = self.format(df)?;
+        Ok(())
+    }
+}

--- a/src/formatters.rs
+++ b/src/formatters.rs
@@ -111,7 +111,9 @@ impl OutputGenerator for GeoJSONSeqFormatter {
         let other_cols = df.drop("geometry")?;
         for (idx, geom) in geometry_col.str()?.into_iter().enumerate() {
             if let Some(wkt_str) = geom {
-                let geom: Geometry<f64> = Geometry::try_from_wkt_str(wkt_str).unwrap();
+                let geom: Geometry<f64> = Geometry::try_from_wkt_str(wkt_str).map_err(|err| {
+                    anyhow!("Invalid `Geometry<f64>` from well-known text string: {err}")
+                })?;
                 let mut properties = serde_json::Map::new();
                 for col in other_cols.get_columns() {
                     let val = any_value_to_json(&col.get(idx)?)?;

--- a/src/formatters.rs
+++ b/src/formatters.rs
@@ -258,11 +258,14 @@ mod tests {
         let formatter = CSVFormatter { geo_format: None };
         let mut df = test_df();
         let output = formatter.format(&mut df);
-        let correct_str = r"int_val,float_val,str_val,geometry
-2,2.0,two,POINT (0 0)
-3,3.0,three,POINT (20 20)
-4,4.0,four,POINT (30 44)
-";
+        let correct_str = [
+            "int_val,float_val,str_val,geometry",
+            "2,2.0,two,POINT (0 0)",
+            "3,3.0,three,POINT (20 20)",
+            "4,4.0,four,POINT (30 44)",
+            "",
+        ]
+        .join("\n");
 
         assert!(output.is_ok(), "Output should not error");
         assert_eq!(output.unwrap(), correct_str, "Output should be correct");

--- a/src/formatters.rs
+++ b/src/formatters.rs
@@ -15,7 +15,7 @@ use wkt::TryFromWkt;
 /// WKB geometries (as a string)
 fn convert_wkt_to_wkb_string(s: Series) -> PolarsResult<Option<Series>> {
     let ca = s.str()?;
-   let wkb_series = ca
+    let wkb_series = ca
         .into_iter()
         .map(|opt_wkt| {
             opt_wkt
@@ -188,7 +188,8 @@ impl OutputGenerator for GeoJSONFormatter {
 
         for (idx, geom) in geometry_col.str()?.into_iter().enumerate() {
             if let Some(wkt_str) = geom {
-                let geom: Geometry<f64> = Geometry::try_from_wkt_str(wkt_str).unwrap();
+                let geom: Geometry<f64> = Geometry::try_from_wkt_str(wkt_str)
+                    .map_err(|_| anyhow!("Failed to parse geometry"))?;
                 let mut properties = serde_json::Map::new();
 
                 for col in other_cols.get_columns() {

--- a/src/formatters.rs
+++ b/src/formatters.rs
@@ -1,18 +1,56 @@
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use enum_dispatch::enum_dispatch;
+use geo::geometry::Geometry;
 use geojson;
-use geojson::{Feature, GeoJson, Geometry, Value};
 use polars::prelude::*;
 use serde::{Deserialize, Serialize};
+use serde_json::json;
+use serde_json::Value;
 use std::io::Cursor;
-use std::{convert::TryFrom, io::Write};
+use std::io::Write;
+use wkt::TryFromWkt;
 
+/// Utility function to convert from polars `AnyValue` to `serde_json::Value`
+/// Doesn't cover all types but most of them.
+fn any_value_to_json(value: &AnyValue) -> Result<Value> {
+    match value {
+        AnyValue::Null => Ok(Value::Null),
+        AnyValue::Boolean(b) => Ok(Value::Bool(*b)),
+        AnyValue::String(s) => Ok(Value::String((*s).to_string())),
+        AnyValue::Int8(n) => Ok(json!(*n)),
+        AnyValue::Int16(n) => Ok(json!(*n)),
+        AnyValue::Int32(n) => Ok(json!(*n)),
+        AnyValue::Int64(n) => Ok(json!(*n)),
+        AnyValue::UInt8(n) => Ok(json!(*n)),
+        AnyValue::UInt16(n) => Ok(json!(*n)),
+        AnyValue::UInt32(n) => Ok(json!(*n)),
+        AnyValue::UInt64(n) => Ok(json!(*n)),
+        AnyValue::Float32(n) => Ok(json!(*n)),
+        AnyValue::Float64(n) => Ok(json!(*n)),
+        AnyValue::Date(d) => Ok(json!(d.to_string())), // You might want to format this
+        AnyValue::Datetime(dt, _, _) => Ok(json!(dt.to_string())), // You might want to format this
+        AnyValue::Time(t) => Ok(json!(t.to_string())), // You might want to format this
+        AnyValue::List(series) => {
+            let json_values: Result<Vec<Value>> =
+                series.iter().map(|val| any_value_to_json(&val)).collect();
+            Ok(Value::Array(json_values?))
+        }
+        _ => Err(anyhow!("Failed to convert type")),
+    }
+}
+
+/// Trait to define different output generators. Defines two
+/// functions, format which generates a serialized string of the
+/// DataFrame and save which generates a file with the generated
+/// file
 #[enum_dispatch]
 pub trait OutputGenerator {
     fn format(&self, df: &mut DataFrame) -> Result<String>;
     fn save(&self, writer: &mut impl Write, df: &mut DataFrame) -> Result<()>;
 }
 
+/// Enum of OutputFormatters one for each potential
+/// output type
 #[enum_dispatch(OutputGenerator)]
 #[derive(Serialize, Deserialize, Debug)]
 pub enum OutputFormatter {
@@ -21,6 +59,9 @@ pub enum OutputFormatter {
     Csv(CSVFormatter),
 }
 
+/// Format the results as geojson sequence format
+/// This is one line per feature serialized as a
+/// geojson feature
 #[derive(Serialize, Deserialize, Debug)]
 pub struct GeoJSONSeqFormatter;
 
@@ -35,15 +76,18 @@ impl OutputGenerator for GeoJSONSeqFormatter {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Default)]
-pub struct GeoJSONFormatter;
-
+/// Define what format geometries are represented in
+///
+/// Wkb: Well known binary
+/// Wkt: Well knoen text
 #[derive(Serialize, Deserialize, Debug)]
 pub enum GeoFormat {
     Wkb,
     Wkt,
 }
 
+/// Format the results as a CSV file with the
+/// geometry encoded in the specified format
 #[derive(Serialize, Deserialize, Debug, Default)]
 pub struct CSVFormatter {
     geo_format: Option<GeoFormat>,
@@ -51,6 +95,7 @@ pub struct CSVFormatter {
 
 impl OutputGenerator for CSVFormatter {
     fn format(&self, df: &mut DataFrame) -> Result<String> {
+        // Just creating an empty vec to store the buffered output
         let mut data: Vec<u8> = vec![0; 200];
         let mut buff = Cursor::new(&mut data);
         self.save(&mut buff, df)?;
@@ -64,13 +109,52 @@ impl OutputGenerator for CSVFormatter {
     }
 }
 
+/// Format the results as a geojson file
+/// TODO there is probably a better way to do this using
+/// geozero to process the dataframe to a file without
+/// having to construct the entire thing in memory first
+#[derive(Serialize, Deserialize, Debug, Default)]
+pub struct GeoJSONFormatter;
+
 impl OutputGenerator for GeoJSONFormatter {
     fn format(&self, df: &mut DataFrame) -> Result<String> {
-        Ok("Test".into())
+        let geometry_col = df.column("geometry")?;
+        let other_cols = df.drop("geometry")?;
+        let mut features: Vec<geojson::Feature> = vec![];
+
+        for (idx, geom) in geometry_col.str()?.into_iter().enumerate() {
+            if let Some(wkt_str) = geom {
+                let geom: Geometry<f64> = Geometry::try_from_wkt_str(wkt_str).unwrap();
+                let mut properties = serde_json::Map::new();
+
+                for col in other_cols.get_columns() {
+                    let val = any_value_to_json(&col.get(idx)?)?;
+                    properties.insert(col.name().to_string(), val);
+                }
+
+                let feature = geojson::Feature {
+                    geometry: Some(geojson::Geometry::from(&geom)),
+                    properties: Some(properties),
+                    bbox: None,
+                    id: None,
+                    foreign_members: None,
+                };
+                features.push(feature);
+            }
+        }
+
+        let feature_collection = geojson::FeatureCollection {
+            bbox: None,
+            features,
+            foreign_members: None,
+        };
+        Ok(feature_collection.to_string())
     }
 
     fn save(&self, writer: &mut impl Write, df: &mut DataFrame) -> Result<()> {
-        let output = self.format(df)?;
+        let result = self.format(df)?;
+        writer.write_all(result.as_bytes())?;
+
         Ok(())
     }
 }

--- a/src/geo.rs
+++ b/src/geo.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use flatgeobuf::{ FeatureProperties, HttpFgbReader, geozero};
 use geozero::ToWkt;
 use anyhow::{Context, Result};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use data_request_spec::DataRequestSpec;
 use metadata::{load_metadata, SourceDataRelease};
-use parquet::{get_metrics, MetricRequest};
+use parquet::get_metrics;
 use polars::{frame::DataFrame, prelude::DataFrameJoinOps};
 use tokio::try_join;
 
@@ -25,8 +25,8 @@ impl Popgetter {
         Ok(Self { metadata })
     }
 
-    /// Given a Data Request Spec 
-    /// Return a DataFrame of the selected dataset 
+    // Given a Data Request Spec 
+    // Return a DataFrame of the selected dataset 
     pub async fn get_data_request(&self, data_request: &DataRequestSpec) -> Result<DataFrame> {
         let metric_requests = data_request.metric_requests(&self.metadata)?;
         let geom_file = data_request.geom_details(&self.metadata)?;
@@ -36,8 +36,8 @@ impl Popgetter {
             get_metrics(&metric_requests,None)
         });
 
-        /// TODO The custom geoid here is because of the legacy US code
-        /// This should be standardized on future pipeline outputs
+        // TODO The custom geoid here is because of the legacy US code
+        // This should be standardized on future pipeline outputs
         let geoms = get_geometries(&geom_file, None, Some("AFFGEOID".into()));
 
         // try_from requires us to have the errors from all futures be the same. 


### PR DESCRIPTION
This PR adds

- A trait and enum for different output formats. This gives us save and format functions to take the data request result and turn it in to either a string or a written file.
- Implementations of this format for CSV output format 
- Code that invokes the CSV formatter as part of the data request

TODO 

- [X] Tests 
- [X] CSV formatter 
- [X] GeoJSON formatter 
- [X] GeoJSONSeq formatter 
- [x] Implement formatter options for different formatter types