### PR TITLE
Allows the bounding box cli argument to accept negative values

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -34,7 +34,7 @@ pub trait RunCommand {
 #[derive(Args, Debug)]
 pub struct DataCommand {
     /// Only get data in  bounding box ([min_lat,min_lng,max_lat,max_lng])
-    #[arg(short, long)]
+    #[arg(short, long, allow_hyphen_values(true))]
     bbox: Option<BBox>,
     /// Only get the specific metrics
     #[arg(short, long)]


### PR DESCRIPTION
Fixes #21 

Bounding box arguments on the command line where not accepting -'ve numbers as clap was interpreting those as short command flags. This allows the bbox arg to have -'ve values