### PR TITLE
New methods for interacting with metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2678,6 +2678,7 @@ dependencies = [
  "geozero",
  "httpmock",
  "polars",
+ "regex",
  "reqwest 0.12.3",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2678,7 +2678,6 @@ dependencies = [
  "geozero",
  "httpmock",
  "polars",
- "regex",
  "reqwest 0.12.3",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = {version="1.0"}
 tokio = { version = "1.30.0", features = ["full"] }
 clap = { version = "4.5.0", features = ["derive"] }
-polars = {version ="0.39.2", features=["lazy","is_in","http","streaming", "parquet","polars-io"]}
+polars = {version ="0.39.2", features = ["lazy","is_in","http","streaming", "parquet","polars-io","regex","strings","rows"]}
 typify = "0.0.16"
 chrono = {version="0.4.37", features=['serde']}
 reqwest = {version = "0.12.3", features = ["json"]}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -4,11 +4,10 @@ use anyhow::Result;
 use clap::{Args, Parser, Subcommand};
 use enum_dispatch::enum_dispatch;
 use popgetter::{
-    data_request_spec::{BBox, DataRequestSpec, GeometrySpec, MetricSpec, RegionSpec},
-    Popgetter,
+    data_request_spec::{BBox, DataRequestSpec, GeometrySpec, MetricSpec, RegionSpec}, formatters::{CSVFormatter, GeoJSONFormatter, GeoJSONSeqFormatter, OutputFormatter, OutputGenerator}, Popgetter
 };
 use serde::{Deserialize, Serialize};
-use std::{fs::{self, File}, str::FromStr};
+use std::fs::File;
 use strum_macros::EnumString;
 
 /// Defines the output formats we are able to produce data in.
@@ -212,6 +211,8 @@ pub enum Commands {
 
 #[cfg(test)]
 mod tests {
+    use std::str::FromStr;
+
     use super::*;
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -4,8 +4,8 @@ use anyhow::Result;
 use clap::{Args, Parser, Subcommand};
 use enum_dispatch::enum_dispatch;
 use popgetter::{
-    data_request_spec::{BBox, DataRequestSpec, MetricSpec, RegionSpec}, 
-    formatters::{CSVFormatter, GeoJSONFormatter, GeoJSONSeqFormatter, OutputFormatter, OutputGenerator}, Popgetter
+    data_request_spec::{BBox, DataRequestSpec, GeometrySpec, MetricSpec, RegionSpec},
+    Popgetter,
 };
 use serde::{Deserialize, Serialize};
 use std::{fs::{self, File}, str::FromStr};
@@ -105,7 +105,12 @@ impl From<&DataCommand> for DataRequestSpec {
         } else {
             vec![]
         };
-        DataRequestSpec { region, metrics }
+
+        DataRequestSpec {
+            geometry: GeometrySpec::default(), 
+            region, 
+            metrics 
+        }
     }
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 use clap::{Args, Parser, Subcommand};
 use enum_dispatch::enum_dispatch;
 use popgetter::{
-    data_request_spec::{BBox, DataRequestSpec, GeometrySpec, MetricSpec, RegionSpec}, formatters::{CSVFormatter, GeoJSONFormatter, GeoJSONSeqFormatter, OutputFormatter, OutputGenerator}, Popgetter
+    data_request_spec::{BBox, DataRequestSpec, GeometrySpec, MetricSpec, RegionSpec}, formatters::{CSVFormatter, GeoJSONFormatter, GeoJSONSeqFormatter, OutputFormatter, OutputGenerator}, metadata::MetricId, Popgetter
 };
 use serde::{Deserialize, Serialize};
 use std::fs::File;
@@ -37,17 +37,60 @@ pub trait RunCommand {
 #[derive(Args, Debug)]
 pub struct DataCommand {
     /// Only get data in  bounding box ([min_lat,min_lng,max_lat,max_lng])
-    #[arg(short, long, allow_hyphen_values(true))]
+    #[arg(short, long, allow_hyphen_values(true), help="Bounding box in which to get the results. Format is: min_lon, min_lat, max_lon, max_lat ")]
     bbox: Option<BBox>,
-    /// Only get the specific metrics
-    #[arg(short, long)]
-    metrics: Option<String>,
+    /// Specify a metric by hxl
+    #[arg(short='h', long, help="Specify a metric by Humanitarian Exchange Language tag")]
+    hxl: Option<Vec<String>>,
+
+    // Specify a metric by id
+    #[arg(short='i', long, help="Specify a metric by uuid, can be a partial uuid")]
+    id: Option<Vec<String>>,
+
+    // Specify a metric by name 
+    #[arg(short='n', long, help="Specify a metric by Human readable name")]
+    name: Option<Vec<String>>,
+
     /// Specify output format
-    #[arg(short='f', long)]
+    #[arg(short='f', long, help="One of GeoJSON, CSV, GeoJSONSeq")]
     output_format: OutputFormat,
 
-    #[arg(short='o',long)]
-    output_file: String
+    /// Specify where the result should be saved
+    #[arg(short='o',long, help="Output file to place the results")]
+    output_file: String,
+
+    /// Specify the years we should get the result for
+    #[arg(short='y', long, help="Specify the year ranges for which you are interested in the metrics")]
+    years: Option<Vec<String>>
+}
+
+
+impl DataCommand{
+    pub fn gather_metric_requests(&self)->Vec<MetricId>{
+        let mut metric_ids: Vec<MetricId> = vec![];
+
+        if let Some(ids) = &self.id{
+            for id in ids{
+                metric_ids.push(MetricId::Id(id.clone()));
+            }
+        } 
+
+        if let Some(hxls) = &self.hxl{
+            for hxl in hxls{
+                metric_ids.push(MetricId::Hxl(hxl.clone()));
+            }
+        } 
+
+        if let Some(names) = &self.name{
+            for name in names{
+                metric_ids.push(MetricId::CommonName(name.clone()));
+            }
+        } 
+
+        metric_ids
+
+    
+    }
 }
 
 impl From<&OutputFormat> for OutputFormatter{
@@ -96,19 +139,16 @@ impl From<&DataCommand> for DataRequestSpec {
             vec![]
         };
 
-        let metrics: Vec<MetricSpec> = if let Some(metric_string) = &value.metrics {
-            metric_string
-                .split(',')
-                .map(|s| MetricSpec::NamedMetric(s.trim().into()))
-                .collect()
-        } else {
-            vec![]
-        };
+        let metrics = value.gather_metric_requests()
+                           .into_iter()
+                           .map(|metric_id| MetricSpec::Metric(metric_id))
+                           .collect();
 
         DataRequestSpec {
             geometry: GeometrySpec::default(), 
             region, 
-            metrics 
+            metrics,
+            years: None, 
         }
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -7,7 +7,7 @@ use popgetter::{
     data_request_spec::{BBox, DataRequestSpec, GeometrySpec, MetricSpec, RegionSpec}, formatters::{CSVFormatter, GeoJSONFormatter, GeoJSONSeqFormatter, OutputFormatter, OutputGenerator}, metadata::MetricId, Popgetter
 };
 use serde::{Deserialize, Serialize};
-use std::fs::File;
+use std::fs::{self, File};
 use strum_macros::EnumString;
 
 /// Defines the output formats we are able to produce data in.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -141,7 +141,7 @@ impl From<&DataCommand> for DataRequestSpec {
 
         let metrics = value.gather_metric_requests()
                            .into_iter()
-                           .map(|metric_id| MetricSpec::Metric(metric_id))
+                           .map(MetricSpec::Metric)
                            .collect();
 
         DataRequestSpec {

--- a/src/data_request_spec.rs
+++ b/src/data_request_spec.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use std::{
     ops::{Index, IndexMut},
@@ -15,6 +15,8 @@ pub struct DataRequestSpec {
 }
 
 impl DataRequestSpec {
+    /// Generates a vector of metric requests from a `DataRequestSpec`
+    /// and a catalouge.
     pub fn metric_requests(&self, catalogue: &Metadata) -> Result<Vec<MetricRequest>> {
         let mut metric_requests: Vec<MetricRequest> = vec![];
         println!("Try to get metrics {:#?}", self.metrics);
@@ -24,8 +26,7 @@ impl DataRequestSpec {
                     metric_requests.push(
                         catalogue
                             .get_metric_details(name)
-                            .with_context(|| "Failed to find metric")?
-                            .into(),
+                            .with_context(|| "Failed to find metric")?,
                     );
                 }
                 MetricSpec::DataProduct(_) => todo!("unsupported metric spec"),
@@ -34,6 +35,8 @@ impl DataRequestSpec {
         Ok(metric_requests)
     }
 
+    /// Get the details of a geometry file from a `DataRequestSpec` and
+    /// a catalouge.
     pub fn geom_details(&self, catalogue: &Metadata) -> Result<String> {
         catalogue.get_geom_details("municipalty")
     }

--- a/src/data_request_spec.rs
+++ b/src/data_request_spec.rs
@@ -109,7 +109,7 @@ impl DataRequestSpec {
             .column("geometry_level")?
             .str()?
             .get(0)
-            .expect("Should have geometry")
+            .ok_or(anyhow!("Filtered possible metrics does not contain 'geometry_level'"))?
             .to_owned();
 
         Ok(MetricRequestResult {

--- a/src/data_request_spec.rs
+++ b/src/data_request_spec.rs
@@ -29,7 +29,7 @@ pub struct DataRequestSpec {
 }
 
 /// This is the response to requesting a set of metrics.
-/// it contains the matched Metric Requests along with
+/// It contains the matched Metric Requests along with
 /// the geometry that was selected we can also potentially
 /// use this to give feedback on other options in the future
 pub struct MetricRequestResult {

--- a/src/data_request_spec.rs
+++ b/src/data_request_spec.rs
@@ -91,7 +91,7 @@ impl DataRequestSpec {
             .zip(
                 filtered_possible_metrics
                     .column("parquet_metric_file")?
-                    .str()?,
+                    .str()?
             )
             .filter_map(|(column, file)| {
                 if let (Some(column), Some(file)) = (column, file) {

--- a/src/data_request_spec.rs
+++ b/src/data_request_spec.rs
@@ -26,7 +26,7 @@ pub struct MetricRequestResult {
 }
 
 impl DataRequestSpec {
-    /// Generates a vector of metric requests from a `DataRequestSpec` and a catalog.
+    /// Generates a vector of metric requests from a `DataRequestSpec` and a catalogue.
     pub fn metric_requests(&self, catalogue: &Metadata) -> Result<MetricRequestResult> {
         // Find all the metrics which match the requested ones, expanding
         // any regex matches as we do so

--- a/src/data_request_spec.rs
+++ b/src/data_request_spec.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Result};
+use anyhow::{anyhow, Context, Result};
 
 use polars::{
     frame::DataFrame,

--- a/src/data_request_spec.rs
+++ b/src/data_request_spec.rs
@@ -63,7 +63,6 @@ impl DataRequestSpec {
         }
 
         // Extract the possible matches for the given metrics
-
         let possible_metrics = possible_metrics.context("Failed to find matching metrics")?;
 
         // If a geometry level is specified filter out only those metrics with the level
@@ -86,20 +85,15 @@ impl DataRequestSpec {
         let filtered_possible_metrics = filtered_possible_metrics.collect()?;
 
         // Iterate through the results and generate the metric requests
-
-        let mut column_iter = filtered_possible_metrics
+        let metric_requests: Vec<MetricRequest> = filtered_possible_metrics
             .column("parquet_metric_id")?
             .str()?
-            .into_iter();
-
-        let mut file_iter = filtered_possible_metrics
-            .column("parquet_metric_file")?
-            .str()?
-            .into_iter();
-
-        let  metric_requests: Vec<MetricRequest> = column_iter
-            .zip(file_iter)
             .into_iter()
+            .zip(
+                filtered_possible_metrics
+                    .column("parquet_metric_file")?
+                    .str()?,
+            )
             .filter_map(|(column, file)| {
                 if let (Some(column), Some(file)) = (column, file) {
                     Some(MetricRequest {

--- a/src/data_request_spec.rs
+++ b/src/data_request_spec.rs
@@ -28,7 +28,7 @@ pub struct DataRequestSpec {
     pub years: Option<Vec<String>>,
 }
 
-/// This is the respone to requesting a set of metrics
+/// This is the response to requesting a set of metrics.
 /// it contains the matched Metric Requests along with
 /// the geometry that was selected we can also potentially
 /// use this to give feedback on other options in the future

--- a/src/data_request_spec.rs
+++ b/src/data_request_spec.rs
@@ -30,8 +30,8 @@ pub struct DataRequestSpec {
 
 /// This is the response to requesting a set of metrics.
 /// It contains the matched Metric Requests along with
-/// the geometry that was selected we can also potentially
-/// use this to give feedback on other options in the future
+/// the geometry that was selected.
+// TODO (enhancement): We can also potentially use this to give feedback on other options in the future
 pub struct MetricRequestResult {
     pub metrics: Vec<MetricRequest>,
     pub selected_geometry: String,

--- a/src/data_request_spec.rs
+++ b/src/data_request_spec.rs
@@ -85,8 +85,6 @@ impl DataRequestSpec {
 
         let filtered_possible_metrics = filtered_possible_metrics.collect()?;
 
-        let mut metric_requests: Vec<MetricRequest> = vec![];
-
         // Iterate through the results and generate the metric requests
 
         let mut column_iter = filtered_possible_metrics
@@ -99,21 +97,20 @@ impl DataRequestSpec {
             .str()?
             .into_iter();
 
-        for _ in 0..filtered_possible_metrics.height() {
-            let column = column_iter
-                .next()
-                .expect("should have as many iterations as rows")
-                .expect("should have a value")
-                .to_owned();
-
-            let file = file_iter
-                .next()
-                .expect("should have as many iterations as rows")
-                .expect("should have a value")
-                .to_owned();
-
-            metric_requests.push(MetricRequest { column, file })
-        }
+        let  metric_requests: Vec<MetricRequest> = column_iter
+            .zip(file_iter)
+            .into_iter()
+            .filter_map(|(column, file)| {
+                if let (Some(column), Some(file)) = (column, file) {
+                    Some(MetricRequest {
+                        column: column.to_owned(),
+                        file: file.to_owned(),
+                    })
+                } else {
+                    None
+                }
+            })
+            .collect();
 
         let selected_geometry = filtered_possible_metrics
             .column("geometry_level")?

--- a/src/data_request_spec.rs
+++ b/src/data_request_spec.rs
@@ -25,7 +25,8 @@ impl DataRequestSpec {
                 MetricSpec::NamedMetric(name) => {
                     metric_requests.push(
                         catalogue
-                            .get_metric_details(name)
+                            // TODO figure out the best way to pass these
+                            .get_metric_details(name, "municipality", "2022")
                             .with_context(|| "Failed to find metric")?,
                     );
                 }

--- a/src/data_request_spec.rs
+++ b/src/data_request_spec.rs
@@ -38,8 +38,7 @@ pub struct MetricRequestResult {
 }
 
 impl DataRequestSpec {
-    /// Generates a vector of metric requests from a `DataRequestSpec`
-    /// and a catalouge.
+    /// Generates a vector of metric requests from a `DataRequestSpec` and a catalog.
     pub fn metric_requests(&self, catalogue: &Metadata) -> Result<MetricRequestResult> {
         let mut possible_metrics: Option<DataFrame> = None;
 

--- a/src/data_request_spec.rs
+++ b/src/data_request_spec.rs
@@ -1,20 +1,21 @@
-use anyhow::{Context, Result};
+use anyhow::{anyhow, Context, Result};
 use serde::{Deserialize, Serialize};
 use std::{
     ops::{Index, IndexMut},
     str::FromStr,
 };
 
-use crate::{metadata::SourceDataRelease, parquet::MetricRequest};
+use crate::{metadata::Metadata, parquet::MetricRequest};
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct DataRequestSpec {
+    pub geometry: GeometrySpec,
     pub region: Vec<RegionSpec>,
     pub metrics: Vec<MetricSpec>,
 }
 
 impl DataRequestSpec {
-    pub fn metric_requests(&self, catalogue: &SourceDataRelease) -> Result<Vec<MetricRequest>> {
+    pub fn metric_requests(&self, catalogue: &Metadata) -> Result<Vec<MetricRequest>> {
         let mut metric_requests: Vec<MetricRequest> = vec![];
         println!("Try to get metrics {:#?}", self.metrics);
         for metric_spec in &self.metrics {
@@ -33,8 +34,8 @@ impl DataRequestSpec {
         Ok(metric_requests)
     }
 
-    pub fn geom_details(&self, catalogue: &SourceDataRelease) -> Result<String> {
-        Ok(catalogue.geography_file.clone())
+    pub fn geom_details(&self, catalogue: &Metadata) -> Result<String> {
+        catalogue.get_geom_details("municipalty")
     }
 }
 
@@ -42,6 +43,21 @@ impl DataRequestSpec {
 pub enum MetricSpec {
     NamedMetric(String),
     DataProduct(String),
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct GeometrySpec {
+    geometry_level: String,
+    include_geoms: bool,
+}
+
+impl Default for GeometrySpec {
+    fn default() -> Self {
+        Self {
+            include_geoms: true,
+            geometry_level: "admin2".into(),
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/src/formatters.rs
+++ b/src/formatters.rs
@@ -13,7 +13,7 @@ use wkt::TryFromWkt;
 
 /// Utility function to convert a polars series from WKT geometries to
 /// WKB geometries (as a string)
-fn convert_wkt_to_wkb_string(s: Series) -> PolarsResult<Option<Series>> {
+fn convert_wkt_to_wkb_string(s: &Series) -> PolarsResult<Option<Series>> {
     let ca = s.str()?;
     let wkb_series = ca
         .into_iter()
@@ -159,7 +159,7 @@ impl OutputGenerator for CSVFormatter {
                 .with_column(
                     col("geometry")
                         .map(
-                            convert_wkt_to_wkb_string,
+                            |s: Series| convert_wkt_to_wkb_string(&s),
                             GetOutput::from_type(DataType::String),
                         )
                         .alias("geometry"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@ use parquet::get_metrics;
 use polars::{frame::DataFrame, prelude::DataFrameJoinOps};
 use tokio::try_join;
 
-use crate::geo::get_geometries;
+use crate::{data_request_spec::MetricSpec, geo::get_geometries};
 pub mod data_request_spec;
 pub mod error;
 pub mod geo;
@@ -30,16 +30,14 @@ impl Popgetter {
     // Return a DataFrame of the selected dataset 
     pub async fn get_data_request(&self, data_request: &DataRequestSpec) -> Result<DataFrame> {
         let metric_requests = data_request.metric_requests(&self.metadata)?;
-        let geom_file = data_request.geom_details(&self.metadata)?;
 
         // Required because polars is blocking
         let metrics = tokio::task::spawn_blocking(move || {
-            get_metrics(&metric_requests,None)
+            get_metrics(&metric_requests.metrics,None)
         });
-
-        // TODO The custom geoid here is because of the legacy US code
-        // This should be standardized on future pipeline outputs
-        let geoms = get_geometries(&geom_file, None, Some("AFFGEOID".into()));
+        
+        let geom_file  = self.metadata.get_geom_details(&metric_requests.selected_geometry)?;
+        let geoms = get_geometries(&geom_file, None, None);
 
         // try_join requires us to have the errors from all futures be the same. 
         // We use anyhow to get it back properly

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@ use parquet::get_metrics;
 use polars::{frame::DataFrame, prelude::DataFrameJoinOps};
 use tokio::try_join;
 
-use crate::{data_request_spec::MetricSpec, geo::get_geometries};
+use crate::{geo::get_geometries};
 pub mod data_request_spec;
 pub mod error;
 pub mod geo;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use data_request_spec::DataRequestSpec;
 use metadata::Metadata;
-use parquet::{get_metrics, MetricRequest};
+use parquet::get_metrics;
 use polars::{frame::DataFrame, prelude::DataFrameJoinOps};
 use tokio::try_join;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use data_request_spec::DataRequestSpec;
-use metadata::{load_metadata, SourceDataRelease};
-use parquet::get_metrics;
+use metadata::Metadata;
+use parquet::{get_metrics, MetricRequest};
 use polars::{frame::DataFrame, prelude::DataFrameJoinOps};
 use tokio::try_join;
 
@@ -16,13 +16,13 @@ pub mod parquet;
 pub mod formatters;
 
 pub struct Popgetter {
-    pub metadata: SourceDataRelease,
+    pub metadata: Metadata,
 }
 
 impl Popgetter {
     /// Setup the Popgetter object 
     pub fn new() -> Result<Self> {
-        let metadata = load_metadata("us_metadata_test2.json")?;
+        let metadata = metadata::load_all(&["be"])?;
         Ok(Self { metadata })
     }
 

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -194,7 +194,7 @@ impl Metadata {
     }
 
     /// Given a geometry level return the path to the
-    /// geometry file that it corrisponds to
+    /// geometry file that it corresponds to
     pub fn get_geom_details(&self, geom_level: &str) -> Result<String> {
         let matches = self
             .geometries

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -270,7 +270,6 @@ impl Metadata {
     /// If our metric_id is a regex, expand it in to a list of explicit `MetricIds`
     pub fn expand_regex_metric(&self, metric_id: &MetricId) -> Result<Vec<MetricId>> {
         let col_name = metric_id.to_col_name();
-        let query = metric_id.to_query_string();
         let catalogue = self.combined_metric_source_geometry();
 
         catalogue
@@ -366,7 +365,7 @@ impl Metadata {
         let selected_years = if let Some(years) = years {
             years.clone()
         } else {
-            let mut avaliable_years = possible_metrics
+            let avaliable_years = possible_metrics
                 .select_geometry(&selected_geometry)
                 .avaliable_years()?;
 

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -104,9 +104,9 @@ pub struct CountryMetadataLoader {
 
 /// A structure that represents a full joined lazy data frame
 /// containing all of the metadata
-pub struct ExpandedMetdataTable(pub LazyFrame);
+pub struct ExpandedMetadataTable(pub LazyFrame);
 
-impl ExpandedMetdataTable {
+impl ExpandedMetadataTable {
     /// Get access to the lazy data frame
     pub fn as_df(&self) -> LazyFrame {
         self.0.clone()
@@ -133,7 +133,7 @@ impl ExpandedMetdataTable {
             };
         }
 
-        ExpandedMetdataTable(self.as_df().filter(filter_expression.unwrap()))
+        ExpandedMetadataTable(self.as_df().filter(filter_expression.unwrap()))
     }
 
     /// Convert the metrics in the dataframe to MetricRequests
@@ -164,7 +164,7 @@ impl ExpandedMetdataTable {
 
     /// Select a specific geometry level in the dataframe filtering out all others
     pub fn select_geometry(&self, geometry: &str) -> Self {
-        ExpandedMetdataTable(self.as_df().filter(col("geometry_level").eq(geometry)))
+        ExpandedMetadataTable(self.as_df().filter(col("geometry_level").eq(geometry)))
     }
 
     /// Select a specific set of years in the dataframe filtering out all others
@@ -174,7 +174,7 @@ impl ExpandedMetdataTable {
     {
         let years: Vec<&str> = years.iter().map(std::convert::AsRef::as_ref).collect();
         let years_series = Series::new("years", years);
-        ExpandedMetdataTable(self.as_df().filter(col("year").is_in(lit(years_series))))
+        ExpandedMetadataTable(self.as_df().filter(col("year").is_in(lit(years_series))))
     }
 
     /// Return a ranked list of avaliable geometries
@@ -294,9 +294,9 @@ impl Metadata {
     }
 
     /// Generate a Lazy DataFrame which joins the metrics, source and geometry metadata
-    fn combined_metric_source_geometry(&self) -> ExpandedMetdataTable {
+    fn combined_metric_source_geometry(&self) -> ExpandedMetadataTable {
         // Join with source_data_release and geometry
-        ExpandedMetdataTable(
+        ExpandedMetadataTable(
             self.metrics
                 .clone()
                 .lazy()

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -290,8 +290,7 @@ pub fn load_all(countries: &[&str]) -> Result<Metadata> {
     let data_publishers =
         polars::prelude::concat(data_publisher_dfs, UnionArgs::default())?.collect()?;
 
-    // Merge coutnries
-
+    // Merge countries
     let countries_dfs: Vec<LazyFrame> = metadata
         .iter()
         .map(|m| m.countries.clone().lazy())

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -96,7 +96,7 @@ impl Default for CountryMetadataPaths {
 
 /// `CountryMetadataLoader` takes a country iso string
 /// along with a CountryMetadataPaths and provides methods
-/// for fetching and construting a `Metadata` catalouge.
+/// for fetching and construting a `Metadata` catalogue.
 pub struct CountryMetadataLoader {
     country: String,
     paths: CountryMetadataPaths,
@@ -233,7 +233,7 @@ impl ExpandedMetdataTable {
 /// the various different metadata tables. Can be constructed
 /// from a single `CountryMetadataLoader` or for all countries.
 /// It also provides the various functions for searching and
-/// getting `MetricRequests` from the catalouge.
+/// getting `MetricRequests` from the catalogue.
 #[derive(Debug)]
 pub struct Metadata {
     pub metrics: DataFrame,
@@ -271,9 +271,9 @@ impl Metadata {
     pub fn expand_regex_metric(&self, metric_id: &MetricId) -> Result<Vec<MetricId>> {
         let col_name = metric_id.to_col_name();
         let query = metric_id.to_query_string();
-        let catalouge = self.combined_metric_source_geometry();
+        let catalogue = self.combined_metric_source_geometry();
 
-        catalouge
+        catalogue
             .as_df()
             .filter(metric_id.to_fuzzy_polars_expr())
             .collect()?
@@ -433,7 +433,7 @@ impl CountryMetadataLoader {
         self
     }
 
-    /// Load the Metadata catalouge for this country with
+    /// Load the Metadata catalogue for this country with
     /// the specified metadata paths
     pub fn load(&self) -> Result<Metadata> {
         Ok(Metadata {
@@ -456,7 +456,7 @@ impl CountryMetadataLoader {
 }
 
 /// Load the metadata for a list of countries and merge them into
-/// a single `Metadata` catalouge.
+/// a single `Metadata` catalogue.
 pub fn load_all(countries: &[&str]) -> Result<Metadata> {
     let metadata: Result<Vec<Metadata>> = countries
         .iter()

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -74,9 +74,9 @@ impl MetricId {
     }
 }
 
-impl Into<Expr> for MetricId {
-    fn into(self) -> Expr {
-        self.to_polars_expr()
+impl From<MetricId> for Expr {
+    fn from(value: MetricId) -> Self {
+        value.to_polars_expr()
     }
 }
 

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -119,7 +119,7 @@ pub struct Metadata {
 
 impl Metadata {
     /// If our metric_id is a regex, expand it in to a list of explicit `MetricIds`
-    pub fn expand_wildcard_metric(&self, metric_id: &MetricId) -> Result<Vec<MetricId>> {
+    pub fn expand_regex_metric(&self, metric_id: &MetricId) -> Result<Vec<MetricId>> {
         let col_name = metric_id.to_col_name();
         let query = metric_id.to_query_string();
         let catalouge = self.combined_metric_source_geometry();

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -1,6 +1,8 @@
 use anyhow::{anyhow, Result};
+
 use polars::{
-    frame::{explode, DataFrame},
+    chunked_array::ops::SortMultipleOptions,
+    frame::DataFrame,
     lazy::{
         dsl::{col, Expr},
         frame::{IntoLazy, LazyFrame, ScanArgsParquet},
@@ -8,11 +10,10 @@ use polars::{
     prelude::{lit, JoinArgs, JoinType, NamedFrom, UnionArgs},
     series::Series,
 };
-use regex::Regex;
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, default::Default};
+use std::{collections::HashMap, default::Default, fmt::Display};
 
-use crate::parquet::MetricRequest;
+use crate::{data_request_spec::GeometrySpec, parquet::MetricRequest};
 
 /// This struct contains the base url and names of
 /// the files that contain the metadata. It has a
@@ -53,9 +54,7 @@ impl MetricId {
     /// Return a string representing the textual content of the ID
     pub fn to_query_string(&self) -> &str {
         match self {
-            MetricId::Hxl(s) => s,
-            MetricId::Id(s) => s,
-            MetricId::CommonName(s) => s,
+            MetricId::CommonName(s) | MetricId::Id(s) | MetricId::Hxl(s) => s,
         }
     }
 
@@ -103,6 +102,125 @@ pub struct CountryMetadataLoader {
     paths: CountryMetadataPaths,
 }
 
+pub struct ExpandedMetdataTable(pub LazyFrame);
+
+impl ExpandedMetdataTable {
+    pub fn as_df(&self) -> LazyFrame {
+        self.0.clone()
+    }
+
+    pub fn select_metrics(&self, metrics: &[MetricId]) -> Self {
+        let mut id_collections: HashMap<String, Vec<String>> = HashMap::new();
+
+        for metric in metrics {
+            id_collections
+                .entry(metric.to_col_name())
+                .and_modify(|e| e.push(metric.to_query_string().into()))
+                .or_insert(vec![metric.to_query_string().into()]);
+        }
+
+        let mut filter_expression: Option<Expr> = None;
+        for (col_name, ids) in &id_collections {
+            let filter_series = Series::new("filter", ids.clone());
+            filter_expression = if let Some(expression) = filter_expression {
+                Some(expression.or(col(col_name).is_in(lit(filter_series))))
+            } else {
+                Some(col(col_name).is_in(lit(filter_series)))
+            };
+        }
+
+        ExpandedMetdataTable(self.as_df().filter(filter_expression.unwrap()))
+    }
+
+    pub fn to_metric_requests(&self) -> Result<Vec<MetricRequest>> {
+        let df = self
+            .as_df()
+            .select([col("parquet_metric_file"), col("parquet_metric_id")])
+            .collect()?;
+
+        let metric_requests: Vec<MetricRequest> = df
+            .column("parquet_metric_id")?
+            .str()?
+            .into_iter()
+            .zip(df.column("parquet_metric_file")?.str()?)
+            .filter_map(|(column, file)| {
+                if let (Some(column), Some(file)) = (column, file) {
+                    Some(MetricRequest {
+                        column: column.to_owned(),
+                        file: file.to_owned(),
+                    })
+                } else {
+                    None
+                }
+            })
+            .collect();
+        Ok(metric_requests)
+    }
+
+    pub fn select_geometry(&self, geometry: &str) -> Self {
+        ExpandedMetdataTable(self.as_df().filter(col("geometry_level").eq(geometry)))
+    }
+    pub fn select_years<T>(&self, years: &[T]) -> Self
+    where
+        T: AsRef<str>,
+    {
+        let years: Vec<&str> = years.iter().map(std::convert::AsRef::as_ref).collect();
+        let years_series = Series::new("years", years);
+        ExpandedMetdataTable(self.as_df().filter(col("year").is_in(lit(years_series))))
+    }
+
+    /// Return a ranked list of avaliable geometries
+    pub fn avaliable_geometries(&self) -> Result<Vec<String>> {
+        let df = self.as_df();
+        let counts: DataFrame = df
+            .group_by([col("geometry_level")])
+            .agg([col("goemetry_level").count().alias("count")])
+            .sort(
+                ["count"],
+                SortMultipleOptions::new().with_order_descending(true),
+            )
+            .collect()?;
+
+        Ok(counts
+            .column("geometry_level")?
+            .str()?
+            .iter()
+            .filter_map(|geom| geom.map(std::borrow::ToOwned::to_owned))
+            .collect())
+    }
+
+    /// Return a ranked list of avaliable years
+    pub fn avaliable_years(&self) -> Result<Vec<String>> {
+        let df = self.as_df();
+        let counts: DataFrame = df
+            .group_by([col("year")])
+            .agg([col("year").count().alias("count")])
+            .sort(
+                ["count"],
+                SortMultipleOptions::new().with_order_descending(true),
+            )
+            .collect()?;
+
+        Ok(counts
+            .column("year")?
+            .str()?
+            .iter()
+            .filter_map(|geom| geom.map(std::borrow::ToOwned::to_owned))
+            .collect())
+    }
+
+    /// Get fully speced metric ids
+    pub fn get_explicit_metric_ids(&self) -> Result<Vec<MetricId>> {
+        let reamining: DataFrame = self.as_df().select([col("metric_id")]).collect()?;
+        Ok(reamining
+            .column("id")?
+            .str()?
+            .into_iter()
+            .filter_map(|pos_id| pos_id.map(|id| MetricId::Id(id.to_owned())))
+            .collect())
+    }
+}
+
 /// The metadata struct contains the polars `DataFrames` for
 /// the various different metadata tables. Can be constructed
 /// from a single `CountryMetadataLoader` or for all countries.
@@ -117,6 +235,25 @@ pub struct Metadata {
     pub countries: DataFrame,
 }
 
+pub struct FullSelectionPlan {
+    pub explicit_metric_ids: Vec<MetricId>,
+    pub geometry: String,
+    pub year: Vec<String>,
+    pub advice: String,
+}
+
+impl Display for FullSelectionPlan {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Getting {} metrics \n, on {} geometries \n , for the years {}",
+            self.explicit_metric_ids.len(),
+            self.geometry,
+            self.year.join(",")
+        )
+    }
+}
+
 impl Metadata {
     /// If our metric_id is a regex, expand it in to a list of explicit `MetricIds`
     pub fn expand_regex_metric(&self, metric_id: &MetricId) -> Result<Vec<MetricId>> {
@@ -125,6 +262,7 @@ impl Metadata {
         let catalouge = self.combined_metric_source_geometry();
 
         catalouge
+            .as_df()
             .filter(metric_id.to_fuzzy_polars_expr())
             .collect()?
             .column(&col_name)?
@@ -145,52 +283,101 @@ impl Metadata {
     }
 
     /// Generate a Lazy DataFrame which joins the metrics, source and geometry metadata
-    fn combined_metric_source_geometry(&self) -> LazyFrame {
+    fn combined_metric_source_geometry(&self) -> ExpandedMetdataTable {
         // Join with source_data_release and geometry
-        self.metrics
-            .clone()
-            .lazy()
-            .join(
-                self.source_data_releases.clone().lazy(),
-                [col("source_data_release_id")],
-                [col("id")],
-                JoinArgs::new(JoinType::Inner),
-            )
-            .join(
-                self.geometries.clone().lazy(),
-                [col("geometry_metadata_id")],
-                [col("id")],
-                JoinArgs::new(JoinType::Inner),
-            )
+        ExpandedMetdataTable(
+            self.metrics
+                .clone()
+                .lazy()
+                .join(
+                    self.source_data_releases.clone().lazy(),
+                    [col("source_data_release_id")],
+                    [col("id")],
+                    JoinArgs::new(JoinType::Inner),
+                )
+                .join(
+                    self.geometries.clone().lazy(),
+                    [col("geometry_metadata_id")],
+                    [col("id")],
+                    JoinArgs::new(JoinType::Inner),
+                ),
+        )
     }
 
-    /// Given a list of metric ids return a Data Frame with the
-    /// list of possible matches across years and geometries
-    pub fn get_possible_metric_details(&self, metrics: &[MetricId]) -> Result<DataFrame> {
-        let mut id_collections: HashMap<String, Vec<String>> = HashMap::new();
+    pub fn get_metric_requests(&self, metric_ids: Vec<MetricId>) -> Result<Vec<MetricRequest>> {
+        self.combined_metric_source_geometry()
+            .select_metrics(&metric_ids);
+        Ok(vec![])
+    }
 
-        for metric in metrics {
-            id_collections
-                .entry(metric.to_col_name())
-                .and_modify(|e| e.push(metric.to_query_string().into()))
-                .or_insert(vec![metric.to_query_string().into()]);
-        }
-
-        let mut filter_expression: Option<Expr> = None;
-        for (col_name, ids) in &id_collections {
-            let filter_series = Series::new("filter", ids.clone());
-            filter_expression = if let Some(expression) = filter_expression {
-                Some(expression.or(col(col_name).is_in(lit(filter_series))))
-            } else {
-                Some(col(col_name).is_in(lit(filter_series)))
-            };
-        }
-
-        let metrics = self
+    pub fn generate_selection_plan(
+        &self,
+        metrics: &[MetricId],
+        geometry: &GeometrySpec,
+        years: &Option<Vec<String>>,
+    ) -> Result<FullSelectionPlan> {
+        let mut advice: Vec<String> = vec![];
+        // Find metadata for all specified metrics over all geoemtries and years
+        let possible_metrics = self
             .combined_metric_source_geometry()
-            .filter(filter_expression.unwrap())
-            .collect()?;
-        Ok(metrics)
+            .select_metrics(metrics);
+
+        // If the user has selected a geometry, we will use it explicitly
+        let selected_geometry = if let Some(geom) = &geometry.geometry_level {
+            geom.clone()
+        }
+        // Otherwise we will get the geometry with the most matches to our
+        // metrics
+        else {
+            // Get a ranked list of geometriesthat are avaliable for these
+            // metrics
+            let avaliable_geometries = possible_metrics.avaliable_geometries()?;
+            if avaliable_geometries.is_empty() {
+                return Err(anyhow!(
+                    "No geometry specifed and non found for these metrics"
+                ));
+            }
+
+            let geom = avaliable_geometries[0].to_owned();
+            if avaliable_geometries.len() > 1 {
+                let rest = avaliable_geometries[1..].join(",");
+                advice.push(format!("We are selecting the geometry level {geom}. The requested metrics are also avaliable at the following levels: {rest}"));
+            }
+            geom
+        };
+
+        // If the user has selected a set of years, we will use them explicity
+        let selected_years = if let Some(years) = years {
+            years.clone()
+        } else {
+            let mut avaliable_years = possible_metrics
+                .select_geometry(&selected_geometry)
+                .avaliable_years()?;
+
+            if avaliable_years.is_empty() {
+                return Err(anyhow!(
+                    "No year specified and no year matches found given the geometry level {selected_geometry}"
+                ));
+            }
+            let year = avaliable_years[0].to_owned();
+            if avaliable_years.len() > 1 {
+                let rest = avaliable_years[1..].join(",");
+                advice.push(format!("We automatically selected the year {year}. The requested metrics are also avaiable in the follow time spans {rest}"));
+            }
+            vec![year]
+        };
+
+        let metrics = possible_metrics
+            .select_geometry(&selected_geometry)
+            .select_years(&selected_years)
+            .get_explicit_metric_ids()?;
+
+        Ok(FullSelectionPlan {
+            explicit_metric_ids: metrics,
+            geometry: selected_geometry,
+            year: selected_years,
+            advice: advice.join("\n"),
+        })
     }
 
     /// Given a geometry level return the path to the
@@ -309,7 +496,6 @@ pub fn load_all(countries: &[&str]) -> Result<Metadata> {
 
 #[cfg(test)]
 mod tests {
-    use geo::Extremes;
 
     use super::*;
     /// TODO stub out a mock here that we can use to test with.
@@ -331,8 +517,7 @@ mod tests {
     #[test]
     fn metric_ids_should_expand_properly() {
         let metadata = load_all(&["be"]).unwrap();
-        let expanded_metrics =
-            metadata.expand_wildcard_metric(&MetricId::Hxl("population-*".into()));
+        let expanded_metrics = metadata.expand_regex_metric(&MetricId::Hxl("population-*".into()));
         assert!(
             expanded_metrics.is_ok(),
             "Should successfully expand metrics"
@@ -347,7 +532,7 @@ mod tests {
 
         let metric_names: Vec<&str> = expanded_metrics
             .iter()
-            .map(|m| m.to_query_string())
+            .map(metadata::MetricId::to_query_string)
             .collect();
 
         assert_eq!(
@@ -369,9 +554,7 @@ mod tests {
     fn human_readable_metric_ids_should_expand_properly() {
         let metadata = load_all(&["be"]).unwrap();
         let expanded_metrics =
-            metadata.expand_wildcard_metric(&MetricId::CommonName("Children*".into()));
-
-        println!("{:#?}", expanded_metrics);
+            metadata.expand_regex_metric(&MetricId::CommonName("Children*".into()));
 
         assert!(
             expanded_metrics.is_ok(),
@@ -388,7 +571,7 @@ mod tests {
 
         let metric_names: Vec<&str> = expanded_metrics
             .iter()
-            .map(|m| m.to_query_string())
+            .map(MetricId::to_query_string)
             .collect();
 
         assert_eq!(
@@ -400,8 +583,8 @@ mod tests {
     #[test]
     fn fully_defined_metric_ids_should_expand_to_itself() {
         let metadata = load_all(&["be"]).unwrap();
-        let expanded_metrics = metadata
-            .expand_wildcard_metric(&MetricId::Hxl(r"#population\+infants\+age0\_4".into()));
+        let expanded_metrics =
+            metadata.expand_regex_metric(&MetricId::Hxl(r"#population\+infants\+age0\_4".into()));
         assert!(
             expanded_metrics.is_ok(),
             "Should successfully expand metrics"
@@ -416,7 +599,7 @@ mod tests {
 
         let metric_names: Vec<&str> = expanded_metrics
             .iter()
-            .map(|m| m.to_query_string())
+            .map(MetricId::to_query_string)
             .collect();
 
         assert_eq!(

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -66,7 +66,7 @@ impl MetricId {
     }
 
     /// Generate a polars Expr that will generate
-    /// a fuzzy search for the content of the Id
+    /// a regex search for the content of the Id
     pub fn to_fuzzy_polars_expr(&self) -> Expr {
         col(&self.to_col_name())
             .str()

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -548,7 +548,7 @@ mod tests {
 
         let metric_names: Vec<&str> = expanded_metrics
             .iter()
-            .map(metadata::MetricId::to_query_string)
+            .map(MetricId::to_query_string)
             .collect();
 
         assert_eq!(

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -1,13 +1,16 @@
 use anyhow::{anyhow, Result};
 use polars::{
-    frame::DataFrame,
+    frame::{explode, DataFrame},
     lazy::{
-        dsl::col,
+        dsl::{col, Expr},
         frame::{IntoLazy, LazyFrame, ScanArgsParquet},
     },
-    prelude::{lit, JoinArgs, JoinType, UnionArgs},
+    prelude::{lit, JoinArgs, JoinType, NamedFrom, UnionArgs},
+    series::Series,
 };
-use std::default::Default;
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+use std::{collections::HashMap, default::Default};
 
 use crate::parquet::MetricRequest;
 
@@ -23,6 +26,58 @@ pub struct CountryMetadataPaths {
     country: String,
     source_data: String,
     data_publishers: String,
+}
+
+/// Represents a way of refering to a metric id
+/// can be converted into a polars expression for
+/// selection
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug)]
+pub enum MetricId {
+    /// Hxl (Humanitarian Exchange Language) tag
+    Hxl(String),
+    /// Internal UUID
+    Id(String),
+    /// Human Readable name
+    CommonName(String),
+}
+
+impl MetricId {
+    /// Returns the column in the metadata that this id type corrispondes to
+    pub fn to_col_name(&self) -> String {
+        match self {
+            MetricId::Hxl(_) => "hxl_tag".into(),
+            MetricId::Id(_) => "id".into(),
+            MetricId::CommonName(_) => "human_readable_name".into(),
+        }
+    }
+    /// Return a string representing the textual content of the ID
+    pub fn to_query_string(&self) -> &str {
+        match self {
+            MetricId::Hxl(s) => s,
+            MetricId::Id(s) => s,
+            MetricId::CommonName(s) => s,
+        }
+    }
+
+    /// Generate a polars Expr that will do
+    /// an exact match on the MetricId
+    pub fn to_polars_expr(&self) -> Expr {
+        col(&self.to_col_name()).eq(self.to_query_string())
+    }
+
+    /// Generate a polars Expr that will generate
+    /// a fuzzy search for the content of the Id
+    pub fn to_fuzzy_polars_expr(&self) -> Expr {
+        col(&self.to_col_name())
+            .str()
+            .contains(lit(self.to_query_string()), false)
+    }
+}
+
+impl Into<Expr> for MetricId {
+    fn into(self) -> Expr {
+        self.to_polars_expr()
+    }
 }
 
 impl Default for CountryMetadataPaths {
@@ -63,6 +118,33 @@ pub struct Metadata {
 }
 
 impl Metadata {
+    /// If our metric_id is a regex, expand it in to a list of explicit `MetricIds`
+    pub fn expand_wildcard_metric(&self, metric_id: &MetricId) -> Result<Vec<MetricId>> {
+        let col_name = metric_id.to_col_name();
+        let query = metric_id.to_query_string();
+        let catalouge = self.combined_metric_source_geometry();
+
+        catalouge
+            .filter(metric_id.to_fuzzy_polars_expr())
+            .collect()?
+            .column(&col_name)?
+            .str()?
+            .iter()
+            .map(|expanded_id| {
+                if let Some(id) = expanded_id {
+                    Ok(match metric_id {
+                        MetricId::Hxl(_) => MetricId::Hxl(id.into()),
+                        MetricId::Id(_) => MetricId::Id(id.into()),
+                        MetricId::CommonName(_) => MetricId::CommonName(id.into()),
+                    })
+                } else {
+                    Err(anyhow!("Failed to expand id"))
+                }
+            })
+            .collect()
+    }
+
+    /// Generate a Lazy DataFrame which joins the metrics, source and geometry metadata
     fn combined_metric_source_geometry(&self) -> LazyFrame {
         // Join with source_data_release and geometry
         self.metrics
@@ -81,42 +163,34 @@ impl Metadata {
                 JoinArgs::new(JoinType::Inner),
             )
     }
-    /// Given a `metric_id`, geometry_level and year, return the
-    /// `MetricRequest` object that can be used to fetch that metric
-    pub fn get_metric_details(
-        &self,
-        metric_id: &str,
-        geometry_level: &str,
-        year: &str,
-    ) -> Result<MetricRequest> {
-        let matches = self
-            .combined_metric_source_geometry()
-            .filter(
-                col("hxl_tag").eq(lit(metric_id)
-                    .and(col("geometry_level").eq(lit(geometry_level)))
-                    .and(col("year").eq(lit(year)))),
-            )
-            .collect()?;
 
-        if matches.height() == 0 {
-            Err(anyhow!("Failed to find metric"))
-        } else if matches.height() > 1 {
-            Err(anyhow!("Multiple metrics match this id"))
-        } else {
-            let column: String = matches
-                .column("metric_parquet_column")?
-                .str()?
-                .get(0)
-                .unwrap()
-                .into();
-            let file: String = matches
-                .column("metric_parquet_file_url")?
-                .str()?
-                .get(0)
-                .unwrap()
-                .into();
-            Ok(MetricRequest { column, file })
+    /// Given a list of metric ids return a Data Frame with the
+    /// list of possible matches across years and geometries
+    pub fn get_possible_metric_details(&self, metrics: &[MetricId]) -> Result<DataFrame> {
+        let mut id_collections: HashMap<String, Vec<String>> = HashMap::new();
+
+        for metric in metrics {
+            id_collections
+                .entry(metric.to_col_name())
+                .and_modify(|e| e.push(metric.to_query_string().into()))
+                .or_insert(vec![metric.to_query_string().into()]);
         }
+
+        let mut filter_expression: Option<Expr> = None;
+        for (col_name, ids) in &id_collections {
+            let filter_series = Series::new("filter", ids.clone());
+            filter_expression = if let Some(expression) = filter_expression {
+                Some(expression.or(col(col_name).is_in(lit(filter_series))))
+            } else {
+                Some(col(col_name).is_in(lit(filter_series)))
+            };
+        }
+
+        let metrics = self
+            .combined_metric_source_geometry()
+            .filter(filter_expression.unwrap())
+            .collect()?;
+        Ok(metrics)
     }
 
     /// Given a geometry level return the path to the
@@ -236,7 +310,10 @@ pub fn load_all(countries: &[&str]) -> Result<Metadata> {
 
 #[cfg(test)]
 mod tests {
+    use geo::Extremes;
+
     use super::*;
+    /// TODO stub out a mock here that we can use to test with.
 
     #[test]
     fn country_metadata_should_load() {
@@ -253,10 +330,102 @@ mod tests {
     }
 
     #[test]
-    fn we_should_be_able_to_find_metadata_by_id() {
+    fn metric_ids_should_expand_properly() {
         let metadata = load_all(&["be"]).unwrap();
-        let metrics =
-            metadata.get_metric_details("#population+children+age0_17", "municipality", "2022");
-        println!("{metrics:#?}");
+        let expanded_metrics =
+            metadata.expand_wildcard_metric(&MetricId::Hxl("population-*".into()));
+        assert!(
+            expanded_metrics.is_ok(),
+            "Should successfully expand metrics"
+        );
+        let expanded_metrics = expanded_metrics.unwrap();
+
+        assert_eq!(
+            expanded_metrics.len(),
+            7,
+            "should return the correct number of metrics"
+        );
+
+        let metric_names: Vec<&str> = expanded_metrics
+            .iter()
+            .map(|m| m.to_query_string())
+            .collect();
+
+        assert_eq!(
+            metric_names,
+            vec![
+                "#population+children+age5_17",
+                "#population+infants+age0_4",
+                "#population+children+age0_17",
+                "#population+adults+f",
+                "#population+adults+m",
+                "#population+adults",
+                "#population+ind"
+            ],
+            "should get the correct metrics"
+        );
+    }
+
+    #[test]
+    fn human_readable_metric_ids_should_expand_properly() {
+        let metadata = load_all(&["be"]).unwrap();
+        let expanded_metrics =
+            metadata.expand_wildcard_metric(&MetricId::CommonName("Children*".into()));
+
+        println!("{:#?}", expanded_metrics);
+
+        assert!(
+            expanded_metrics.is_ok(),
+            "Should successfully expand metrics"
+        );
+
+        let expanded_metrics = expanded_metrics.unwrap();
+
+        assert_eq!(
+            expanded_metrics.len(),
+            2,
+            "should return the correct number of metrics"
+        );
+
+        let metric_names: Vec<&str> = expanded_metrics
+            .iter()
+            .map(|m| m.to_query_string())
+            .collect();
+
+        assert_eq!(
+            metric_names,
+            vec!["Children aged 5 to 17", "Children aged 0 to 17"],
+            "should get the correct metrics"
+        );
+    }
+    #[test]
+    fn fully_defined_metric_ids_should_expand_to_itself() {
+        let metadata = load_all(&["be"]).unwrap();
+        let expanded_metrics = metadata
+            .expand_wildcard_metric(&MetricId::Hxl(r"#population\+infants\+age0\_4".into()));
+        assert!(
+            expanded_metrics.is_ok(),
+            "Should successfully expand metrics"
+        );
+        let expanded_metrics = expanded_metrics.unwrap();
+
+        assert_eq!(
+            expanded_metrics.len(),
+            1,
+            "should return the correct number of metrics"
+        );
+
+        let metric_names: Vec<&str> = expanded_metrics
+            .iter()
+            .map(|m| m.to_query_string())
+            .collect();
+
+        assert_eq!(
+            metric_names,
+            vec!["#population+infants+age0_4",],
+            "should get the correct metrics"
+        );
+
+        println!("{:#?}", expanded_metrics);
     }
 }

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -207,7 +207,7 @@ impl Metadata {
             .column("filename_stem")?
             .str()?
             .get(0)
-            .unwrap()
+            .ok_or(anyhow!("Matches does not contain 'filename_stem' column"))?
             .into();
 
         Ok(file)


### PR DESCRIPTION
This PR 

- Moves away from using the type based metadata system to the database / dataframe based one.
- It defines a new Metadata object which contains dataframes of each of the metadata tables. 
- It defines metrics to read these per country from azure 
- It defines a function to load and merge all countries in to a single metadata object.
- It defines methods on the metadata struct to find specific metrics 
- It defines methods on the metadata struct to find specific geometries.

TODO 


- [x]  Figure out how to do fallback for year and geometry level if not explicitly specified ( default to latest year and smallest geometry level?)
- [ ]  ~Figure out if we can implement ```From<Row> for MetricMetadata``` etc to get more structured data back from the dataframes~  Opening ticket #40 to perhaps attempt this in the future but it doesn't need to be part of this PR.
- [x]  Decide on a unique metric id column (HXL seems like obvious one but I am not 100% sure if that will exist for all of the data we currently have (for example the US ACS columns)) ( we have decided to allow for specification of the metric using multiple columns with potential wildcarding)
