### PR TITLE
Add popgetter error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2683,6 +2683,7 @@ dependencies = [
  "serde_json",
  "strum",
  "strum_macros 0.26.2",
+ "thiserror",
  "tokio",
  "typify",
  "wkb",
@@ -3617,18 +3618,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.58"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297"
+checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.58"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
+checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ geojson={version="0.24.1", optional=true }
 geo = "0.28.0"
 wkt = "0.10.3"
 wkb = "0.7.1"
+thiserror = "1"
 
 
 [features]

--- a/src/error.rs
+++ b/src/error.rs
@@ -18,14 +18,14 @@ pub enum PopgetterError {
 
 #[cfg(test)]
 mod tests {
-    use anyhow::anyhow;
+    use polars::error::{ErrString, PolarsError};
 
     use super::*;
 
     #[test]
-    fn test_anyhow() {
-        let anyhow_error = anyhow!("An anyhow error");
-        let popgetter_error: PopgetterError = anyhow_error.into();
+    fn test_from_polars_error() {
+        let polars_error = PolarsError::ShapeMismatch(ErrString::from("An example polars error"));
+        let popgetter_error: PopgetterError = polars_error.into();
         println!("{}", popgetter_error);
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,8 +2,6 @@
 
 #[derive(thiserror::Error, Debug)]
 pub enum PopgetterError {
-    #[error("Wrapped anyhow error: {0}")]
-    AnyhowError(#[from] anyhow::Error),
     #[error("Connection failure.")]
     FailedConnection,
     #[error("Metric not found.")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,33 @@
+//! Error types.
+
+#[derive(thiserror::Error, Debug)]
+pub enum PopgetterError {
+    #[error("Wrapped anyhow error: {0}")]
+    AnyhowError(#[from] anyhow::Error),
+    #[error("Connection failure.")]
+    FailedConnection,
+    #[error("Metric not found.")]
+    MetricNotFound(String),
+    #[error("Invalid search syntax: {0}")]
+    InvalidSearchQuery(String),
+    #[error("Non-existent geometry for metric requested: {0}")]
+    NonExistentGeometry(String),
+    #[error("Wrapped polars error: {0}")]
+    PolarsError(#[from] polars::error::PolarsError),
+    #[error("Unknown error.")]
+    Unknown,
+}
+
+#[cfg(test)]
+mod tests {
+    use anyhow::anyhow;
+
+    use super::*;
+
+    #[test]
+    fn test_anyhow() {
+        let anyhow_error = anyhow!("An anyhow error");
+        let popgetter_error: PopgetterError = anyhow_error.into();
+        println!("{}", popgetter_error);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ use tokio::try_join;
 
 use crate::geo::get_geometries;
 pub mod data_request_spec;
+pub mod error;
 pub mod geo;
 pub mod metadata;
 pub mod parquet;


### PR DESCRIPTION
Closes #25.

This PR adds a `PopgetterError` enum with some initial variants for use in lib code.