### PR TITLE
config and logging

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,6 +16,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+    - name: Cache Rust dependencies
+      uses: Swatinem/rust-cache@v2
     - name: Build
       run: cargo build --verbose
     - name: Run tests

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -517,9 +517,9 @@ dependencies = [
 
 [[package]]
 name = "brotli"
-version = "5.0.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19483b140a7ac7174d34b5a581b406c64f84da5409d3e09cf4fff604f9270e67"
+checksum = "d640d25bc63c50fb1f0b545ffd80207d2e10a4c965530809b40ba3386825c391"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -528,9 +528,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "4.0.1"
+version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a45bd2e4095a8b518033b128020dd4a55aab1c0a381ba4404a472630f4bc362"
+checksum = "4e2e4afe60d7dd600fdd3de8d0f08c2b7ec039712e3b6137ff98b7004e82de4f"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -681,7 +681,7 @@ checksum = "b34115915337defe99b2aff5c2ce6771e5fbc4079f4b506301f5cf394c8452f7"
 dependencies = [
  "crossterm",
  "strum",
- "strum_macros",
+ "strum_macros 0.26.2",
  "unicode-width",
 ]
 
@@ -1372,7 +1372,6 @@ dependencies = [
  "ahash",
  "allocator-api2",
  "rayon",
- "serde",
 ]
 
 [[package]]
@@ -2285,9 +2284,9 @@ dependencies = [
 
 [[package]]
 name = "polars"
-version = "0.40.0"
+version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e148396dca5496566880fa19374f3f789a29db94e3eb458afac1497b4bac5442"
+checksum = "0ea21b858b16b9c0e17a12db2800d11aa5b4bd182be6b3022eb537bbfc1f2db5"
 dependencies = [
  "getrandom",
  "polars-arrow",
@@ -2305,9 +2304,9 @@ dependencies = [
 
 [[package]]
 name = "polars-arrow"
-version = "0.40.0"
+version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cb5e11cd0752ae022fa6ca3afa50a14b0301b7ce53c0135828fbb0f4fa8303e"
+checksum = "725b09f2b5ef31279b66e27bbab63c58d49d8f6696b66b1f46c7eaab95e80f75"
 dependencies = [
  "ahash",
  "atoi",
@@ -2352,9 +2351,9 @@ dependencies = [
 
 [[package]]
 name = "polars-compute"
-version = "0.40.0"
+version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89fc4578f826234cdecb782952aa9c479dc49373f81694a7b439c70b6f609ba0"
+checksum = "a796945b14b14fbb79b91ef0406e6fddca2be636e889f81ea5d6ee7d36efb4fe"
 dependencies = [
  "bytemuck",
  "either",
@@ -2368,9 +2367,9 @@ dependencies = [
 
 [[package]]
 name = "polars-core"
-version = "0.40.0"
+version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e490c6bace1366a558feea33d1846f749a8ca90bd72a6748752bc65bb4710b2a"
+checksum = "465f70d3e96b6d0b1a43c358ba451286b8c8bd56696feff020d65702aa33e35c"
 dependencies = [
  "ahash",
  "bitflags 2.5.0",
@@ -2401,9 +2400,9 @@ dependencies = [
 
 [[package]]
 name = "polars-error"
-version = "0.40.0"
+version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08888f58e61599b00f5ea0c2ccdc796b54b9859559cc0d4582733509451fa01a"
+checksum = "5224d5d05e6b8a6f78b75951ae1b5f82c8ab1979e11ffaf5fd41941e3d5b0757"
 dependencies = [
  "object_store",
  "polars-arrow-format",
@@ -2413,30 +2412,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "polars-expr"
-version = "0.40.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4173591920fe56ad55af025f92eb0d08421ca85705c326a640c43856094e3484"
-dependencies = [
- "ahash",
- "bitflags 2.5.0",
- "once_cell",
- "polars-arrow",
- "polars-core",
- "polars-io",
- "polars-ops",
- "polars-plan",
- "polars-time",
- "polars-utils",
- "rayon",
- "smartstring",
-]
-
-[[package]]
 name = "polars-io"
-version = "0.40.0"
+version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5842896aea46d975b425d63f156f412aed3cfde4c257b64fb1f43ceea288074e"
+checksum = "b2c8589e418cbe4a48228d64b2a8a40284a82ec3c98817c0c2bcc0267701338b"
 dependencies = [
  "ahash",
  "async-trait",
@@ -2473,9 +2452,9 @@ dependencies = [
 
 [[package]]
 name = "polars-lazy"
-version = "0.40.0"
+version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e805ea2ebbc6b7749b0afb31b7fc5d32b42b57ba29b984549d43d3a16114c4a5"
+checksum = "89b2632b1af668e2058d5f8f916d8fbde3cac63d03ae29a705f598e41dcfeb7f"
 dependencies = [
  "ahash",
  "bitflags 2.5.0",
@@ -2484,7 +2463,6 @@ dependencies = [
  "once_cell",
  "polars-arrow",
  "polars-core",
- "polars-expr",
  "polars-io",
  "polars-ops",
  "polars-pipe",
@@ -2499,13 +2477,13 @@ dependencies = [
 
 [[package]]
 name = "polars-ops"
-version = "0.40.0"
+version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b0aed7e169c81b98457641cf82b251f52239a668916c2e683abd1f38df00d58"
+checksum = "efdbdb4d9a92109bc2e0ce8e17af5ae8ab643bb5b7ee9d1d74f0aeffd1fbc95f"
 dependencies = [
  "ahash",
  "argminmax",
- "base64 0.22.0",
+ "base64 0.21.7",
  "bytemuck",
  "chrono",
  "chrono-tz",
@@ -2529,13 +2507,13 @@ dependencies = [
 
 [[package]]
 name = "polars-parquet"
-version = "0.40.0"
+version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c70670a9e51cac66d0e77fd20b5cc957dbcf9f2660d410633862bb72f846d5b8"
+checksum = "b421d2196f786fdfe162db614c8485f8308fe41575d4de634a39bbe460d1eb6a"
 dependencies = [
  "ahash",
  "async-stream",
- "base64 0.22.0",
+ "base64 0.21.7",
  "brotli",
  "ethnum",
  "flate2",
@@ -2555,9 +2533,9 @@ dependencies = [
 
 [[package]]
 name = "polars-pipe"
-version = "0.40.0"
+version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a40ae1b3c74ee07e2d1f7cbf56c5d6e15969e45d9b6f0903bd2acaf783ba436"
+checksum = "48700f1d5bd56a15451e581f465c09541492750360f18637b196f995470a015c"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-queue",
@@ -2568,7 +2546,6 @@ dependencies = [
  "polars-arrow",
  "polars-compute",
  "polars-core",
- "polars-expr",
  "polars-io",
  "polars-ops",
  "polars-plan",
@@ -2583,14 +2560,13 @@ dependencies = [
 
 [[package]]
 name = "polars-plan"
-version = "0.40.0"
+version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8daa3541ae7e9af311a4389bc2b21f83349c34c723cc67fa524cdefdaa172d90"
+checksum = "2fb8e2302e20c44defd5be8cad9c96e75face63c3a5f609aced8c4ec3b3ac97d"
 dependencies = [
  "ahash",
  "bytemuck",
  "chrono-tz",
- "either",
  "futures",
  "hashbrown",
  "once_cell",
@@ -2606,15 +2582,15 @@ dependencies = [
  "recursive",
  "regex",
  "smartstring",
- "strum_macros",
+ "strum_macros 0.25.3",
  "version_check",
 ]
 
 [[package]]
 name = "polars-row"
-version = "0.40.0"
+version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deb285f2f3a65b00dd06bef16bb9f712dbb5478f941dab5cf74f9f016d382e40"
+checksum = "a515bdc68c2ae3702e3de70d89601f3b71ca8137e282a226dddb53ee4bacfa2e"
 dependencies = [
  "bytemuck",
  "polars-arrow",
@@ -2624,12 +2600,11 @@ dependencies = [
 
 [[package]]
 name = "polars-sql"
-version = "0.40.0"
+version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a724f699d194cb02c25124d3832f7d4d77f387f1a89ee42f6b9e88ec561d4ad9"
+checksum = "7b4bb7cc1c04c3023d1953b2f1dec50515e8fd8169a5a2bf4967b3b082232db7"
 dependencies = [
  "hex",
- "once_cell",
  "polars-arrow",
  "polars-core",
  "polars-error",
@@ -2643,12 +2618,11 @@ dependencies = [
 
 [[package]]
 name = "polars-time"
-version = "0.40.0"
+version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ebec238d8b6200d9f0c3ce411c8441e950bd5a7df7806b8172d06c1d5a4b97"
+checksum = "efc18e3ad92eec55db89d88f16c22d436559ba7030cf76f86f6ed7a754b673f1"
 dependencies = [
  "atoi",
- "bytemuck",
  "chrono",
  "chrono-tz",
  "now",
@@ -2664,9 +2638,9 @@ dependencies = [
 
 [[package]]
 name = "polars-utils"
-version = "0.40.0"
+version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34e1a907c63abf71e5f21467e2e4ff748896c28196746f631c6c25512ec6102c"
+checksum = "c760b6c698cfe2fbbbd93d6cfb408db14ececfe1d92445dae2229ce1b5b21ae8"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -2735,7 +2709,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strum",
- "strum_macros",
+ "strum_macros 0.26.2",
  "tokio",
  "toml",
  "typify",
@@ -3570,6 +3544,19 @@ name = "strum"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d8cec3501a5194c432b2b7976db6b7d10ec95c253208b45f83f7136aa985e29"
+
+[[package]]
+name = "strum_macros"
+version = "0.25.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.60",
+]
 
 [[package]]
 name = "strum_macros"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2737,9 +2737,11 @@ dependencies = [
  "strum",
  "strum_macros",
  "tokio",
+ "toml",
  "typify",
  "wkb",
  "wkt",
+ "xdg",
 ]
 
 [[package]]
@@ -3337,6 +3339,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79e674e01f999af37c49f70a6ede167a8a60b2503e56c5599532a65baa5969a0"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_tokenstream"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3780,6 +3791,40 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "toml"
+version = "0.8.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e43f8cc456c9704c851ae29c67e17ef65d2c30017c17a9765b89c382dc8bba"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4badfd56924ae69bcc9039335b2e017639ce3f9b001c393c1b2d1ef846ce2cbf"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c127785850e8c20836d49732ae6abfa47616e60bf9d9f57c43c250361a9db96c"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -4300,6 +4345,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
 
 [[package]]
+name = "winnow"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86c949fede1d13936a99f14fafd3e76fd642b556dd2ce96287fbe2e0151bfac6"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "winreg"
 version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4340,6 +4394,12 @@ dependencies = [
  "num-traits",
  "thiserror",
 ]
+
+[[package]]
+name = "xdg"
+version = "2.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213b7324336b53d2414b2db8537e56544d981803139155afa84f76eeebb7a546"
 
 [[package]]
 name = "xxhash-rust"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2697,6 +2697,7 @@ dependencies = [
  "clap",
  "enum_dispatch",
  "flatgeobuf",
+ "futures",
  "geo",
  "geojson",
  "geozero",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -891,6 +891,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_logger"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580"
+dependencies = [
+ "humantime",
+ "is-terminal",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1696,6 +1709,17 @@ name = "ipnet"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
+
+[[package]]
+name = "is-terminal"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "itertools"
@@ -2677,7 +2701,9 @@ dependencies = [
  "geojson",
  "geozero",
  "httpmock",
+ "log",
  "polars",
+ "pretty_env_logger",
  "reqwest 0.12.3",
  "serde",
  "serde_json",
@@ -2700,6 +2726,16 @@ name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
+name = "pretty_env_logger"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "865724d4dbe39d9f3dd3b52b88d859d66bcb2d6a0acfd5ea68a65fb66d4bdc1c"
+dependencies = [
+ "env_logger",
+ "log",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -3613,6 +3649,15 @@ dependencies = [
  "dirs-next",
  "rustversion",
  "winapi",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -517,9 +517,9 @@ dependencies = [
 
 [[package]]
 name = "brotli"
-version = "3.5.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d640d25bc63c50fb1f0b545ffd80207d2e10a4c965530809b40ba3386825c391"
+checksum = "19483b140a7ac7174d34b5a581b406c64f84da5409d3e09cf4fff604f9270e67"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -528,9 +528,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "2.5.1"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e2e4afe60d7dd600fdd3de8d0f08c2b7ec039712e3b6137ff98b7004e82de4f"
+checksum = "9a45bd2e4095a8b518033b128020dd4a55aab1c0a381ba4404a472630f4bc362"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -681,7 +681,7 @@ checksum = "b34115915337defe99b2aff5c2ce6771e5fbc4079f4b506301f5cf394c8452f7"
 dependencies = [
  "crossterm",
  "strum",
- "strum_macros 0.26.2",
+ "strum_macros",
  "unicode-width",
 ]
 
@@ -1372,6 +1372,7 @@ dependencies = [
  "ahash",
  "allocator-api2",
  "rayon",
+ "serde",
 ]
 
 [[package]]
@@ -2284,9 +2285,9 @@ dependencies = [
 
 [[package]]
 name = "polars"
-version = "0.39.2"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea21b858b16b9c0e17a12db2800d11aa5b4bd182be6b3022eb537bbfc1f2db5"
+checksum = "e148396dca5496566880fa19374f3f789a29db94e3eb458afac1497b4bac5442"
 dependencies = [
  "getrandom",
  "polars-arrow",
@@ -2304,9 +2305,9 @@ dependencies = [
 
 [[package]]
 name = "polars-arrow"
-version = "0.39.2"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "725b09f2b5ef31279b66e27bbab63c58d49d8f6696b66b1f46c7eaab95e80f75"
+checksum = "1cb5e11cd0752ae022fa6ca3afa50a14b0301b7ce53c0135828fbb0f4fa8303e"
 dependencies = [
  "ahash",
  "atoi",
@@ -2351,9 +2352,9 @@ dependencies = [
 
 [[package]]
 name = "polars-compute"
-version = "0.39.2"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a796945b14b14fbb79b91ef0406e6fddca2be636e889f81ea5d6ee7d36efb4fe"
+checksum = "89fc4578f826234cdecb782952aa9c479dc49373f81694a7b439c70b6f609ba0"
 dependencies = [
  "bytemuck",
  "either",
@@ -2367,9 +2368,9 @@ dependencies = [
 
 [[package]]
 name = "polars-core"
-version = "0.39.2"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465f70d3e96b6d0b1a43c358ba451286b8c8bd56696feff020d65702aa33e35c"
+checksum = "e490c6bace1366a558feea33d1846f749a8ca90bd72a6748752bc65bb4710b2a"
 dependencies = [
  "ahash",
  "bitflags 2.5.0",
@@ -2400,9 +2401,9 @@ dependencies = [
 
 [[package]]
 name = "polars-error"
-version = "0.39.2"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5224d5d05e6b8a6f78b75951ae1b5f82c8ab1979e11ffaf5fd41941e3d5b0757"
+checksum = "08888f58e61599b00f5ea0c2ccdc796b54b9859559cc0d4582733509451fa01a"
 dependencies = [
  "object_store",
  "polars-arrow-format",
@@ -2412,10 +2413,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "polars-io"
-version = "0.39.2"
+name = "polars-expr"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2c8589e418cbe4a48228d64b2a8a40284a82ec3c98817c0c2bcc0267701338b"
+checksum = "4173591920fe56ad55af025f92eb0d08421ca85705c326a640c43856094e3484"
+dependencies = [
+ "ahash",
+ "bitflags 2.5.0",
+ "once_cell",
+ "polars-arrow",
+ "polars-core",
+ "polars-io",
+ "polars-ops",
+ "polars-plan",
+ "polars-time",
+ "polars-utils",
+ "rayon",
+ "smartstring",
+]
+
+[[package]]
+name = "polars-io"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5842896aea46d975b425d63f156f412aed3cfde4c257b64fb1f43ceea288074e"
 dependencies = [
  "ahash",
  "async-trait",
@@ -2452,9 +2473,9 @@ dependencies = [
 
 [[package]]
 name = "polars-lazy"
-version = "0.39.2"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b2632b1af668e2058d5f8f916d8fbde3cac63d03ae29a705f598e41dcfeb7f"
+checksum = "e805ea2ebbc6b7749b0afb31b7fc5d32b42b57ba29b984549d43d3a16114c4a5"
 dependencies = [
  "ahash",
  "bitflags 2.5.0",
@@ -2463,6 +2484,7 @@ dependencies = [
  "once_cell",
  "polars-arrow",
  "polars-core",
+ "polars-expr",
  "polars-io",
  "polars-ops",
  "polars-pipe",
@@ -2477,13 +2499,13 @@ dependencies = [
 
 [[package]]
 name = "polars-ops"
-version = "0.39.2"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efdbdb4d9a92109bc2e0ce8e17af5ae8ab643bb5b7ee9d1d74f0aeffd1fbc95f"
+checksum = "7b0aed7e169c81b98457641cf82b251f52239a668916c2e683abd1f38df00d58"
 dependencies = [
  "ahash",
  "argminmax",
- "base64 0.21.7",
+ "base64 0.22.0",
  "bytemuck",
  "chrono",
  "chrono-tz",
@@ -2507,13 +2529,13 @@ dependencies = [
 
 [[package]]
 name = "polars-parquet"
-version = "0.39.2"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b421d2196f786fdfe162db614c8485f8308fe41575d4de634a39bbe460d1eb6a"
+checksum = "c70670a9e51cac66d0e77fd20b5cc957dbcf9f2660d410633862bb72f846d5b8"
 dependencies = [
  "ahash",
  "async-stream",
- "base64 0.21.7",
+ "base64 0.22.0",
  "brotli",
  "ethnum",
  "flate2",
@@ -2533,9 +2555,9 @@ dependencies = [
 
 [[package]]
 name = "polars-pipe"
-version = "0.39.2"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48700f1d5bd56a15451e581f465c09541492750360f18637b196f995470a015c"
+checksum = "0a40ae1b3c74ee07e2d1f7cbf56c5d6e15969e45d9b6f0903bd2acaf783ba436"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-queue",
@@ -2546,6 +2568,7 @@ dependencies = [
  "polars-arrow",
  "polars-compute",
  "polars-core",
+ "polars-expr",
  "polars-io",
  "polars-ops",
  "polars-plan",
@@ -2560,13 +2583,14 @@ dependencies = [
 
 [[package]]
 name = "polars-plan"
-version = "0.39.2"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fb8e2302e20c44defd5be8cad9c96e75face63c3a5f609aced8c4ec3b3ac97d"
+checksum = "8daa3541ae7e9af311a4389bc2b21f83349c34c723cc67fa524cdefdaa172d90"
 dependencies = [
  "ahash",
  "bytemuck",
  "chrono-tz",
+ "either",
  "futures",
  "hashbrown",
  "once_cell",
@@ -2582,15 +2606,15 @@ dependencies = [
  "recursive",
  "regex",
  "smartstring",
- "strum_macros 0.25.3",
+ "strum_macros",
  "version_check",
 ]
 
 [[package]]
 name = "polars-row"
-version = "0.39.2"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a515bdc68c2ae3702e3de70d89601f3b71ca8137e282a226dddb53ee4bacfa2e"
+checksum = "deb285f2f3a65b00dd06bef16bb9f712dbb5478f941dab5cf74f9f016d382e40"
 dependencies = [
  "bytemuck",
  "polars-arrow",
@@ -2600,11 +2624,12 @@ dependencies = [
 
 [[package]]
 name = "polars-sql"
-version = "0.39.2"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4bb7cc1c04c3023d1953b2f1dec50515e8fd8169a5a2bf4967b3b082232db7"
+checksum = "a724f699d194cb02c25124d3832f7d4d77f387f1a89ee42f6b9e88ec561d4ad9"
 dependencies = [
  "hex",
+ "once_cell",
  "polars-arrow",
  "polars-core",
  "polars-error",
@@ -2618,11 +2643,12 @@ dependencies = [
 
 [[package]]
 name = "polars-time"
-version = "0.39.2"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efc18e3ad92eec55db89d88f16c22d436559ba7030cf76f86f6ed7a754b673f1"
+checksum = "87ebec238d8b6200d9f0c3ce411c8441e950bd5a7df7806b8172d06c1d5a4b97"
 dependencies = [
  "atoi",
+ "bytemuck",
  "chrono",
  "chrono-tz",
  "now",
@@ -2638,9 +2664,9 @@ dependencies = [
 
 [[package]]
 name = "polars-utils"
-version = "0.39.2"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c760b6c698cfe2fbbbd93d6cfb408db14ececfe1d92445dae2229ce1b5b21ae8"
+checksum = "34e1a907c63abf71e5f21467e2e4ff748896c28196746f631c6c25512ec6102c"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -2709,7 +2735,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strum",
- "strum_macros 0.26.2",
+ "strum_macros",
  "tokio",
  "typify",
  "wkb",
@@ -3533,19 +3559,6 @@ name = "strum"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d8cec3501a5194c432b2b7976db6b7d10ec95c253208b45f83f7136aa985e29"
-
-[[package]]
-name = "strum_macros"
-version = "0.25.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
-dependencies = [
- "heck 0.4.1",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn 2.0.60",
-]
 
 [[package]]
 name = "strum_macros"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,8 @@ geojson={version="0.24.1", optional=true }
 geo = "0.28.0"
 wkt = "0.10.3"
 wkb = "0.7.1"
+log = "0.4.21"
+pretty_env_logger = "0.5.0"
 
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = {version="1.0"}
 tokio = { version = "1.30.0", features = ["full"] }
 clap = { version = "4.5.0", features = ["derive"] }
-polars = {version ="0.40.0", features=["lazy","is_in","http","streaming", "parquet","polars-io"]}
+polars = {version ="0.39.2", features=["lazy","is_in","http","streaming", "parquet","polars-io"]}
 typify = "0.0.16"
 chrono = {version="0.4.37", features=['serde']}
 reqwest = {version = "0.12.3", features = ["json"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ wkt = "0.10.3"
 wkb = "0.7.1"
 log = "0.4.21"
 pretty_env_logger = "0.5.0"
+futures = "0.3.30"
 
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = {version="1.0"}
 tokio = { version = "1.30.0", features = ["full"] }
 clap = { version = "4.5.0", features = ["derive"] }
-polars = {version ="0.39.2", features=["lazy","is_in","http","streaming", "parquet","polars-io"]}
+polars = {version ="0.40.0", features=["lazy","is_in","http","streaming", "parquet","polars-io"]}
 typify = "0.0.16"
 chrono = {version="0.4.37", features=['serde']}
 reqwest = {version = "0.12.3", features = ["json"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,8 @@ wkb = "0.7.1"
 log = "0.4.21"
 pretty_env_logger = "0.5.0"
 futures = "0.3.30"
+toml = "0.8.13"
+xdg = "2.5.2"
 
 
 [features]

--- a/schema/popgetter_0.1.0.json
+++ b/schema/popgetter_0.1.0.json
@@ -1,28 +1,42 @@
 {
-  "title": "popgetter_schema",
-  "definitions": {
+  "$defs": {
     "CountryMetadata": {
-      "title": "CountryMetadata",
-      "type": "object",
       "properties": {
         "name_short_en": {
-          "title": "Name Short En",
           "description": "The short name of the country in English (for example 'Belgium').",
+          "title": "Name Short En",
           "type": "string"
         },
         "name_official": {
-          "title": "Name Official",
           "description": "The official name of the country (for example 'Kingdom of Belgium'). In English if available.",
+          "title": "Name Official",
           "type": "string"
         },
         "iso3": {
+          "description": "The ISO 3166-1 alpha-3 code of the country (for example 'BEL').",
           "title": "Iso3",
-          "description": "The ISO3 code of the country (for example 'BEL').",
           "type": "string"
         },
         "iso2": {
+          "description": "The ISO 3166-1 alpha-2 code of the country (for example 'BE').",
           "title": "Iso2",
-          "description": "The ISO2 code of the country (for example 'BE').",
+          "type": "string"
+        },
+        "iso3166_2": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "If the territory is a 'principal subdivision', its ISO 3166-2 code (for example 'BE-VLG').",
+          "title": "Iso3166 2"
+        },
+        "id": {
+          "readOnly": true,
+          "title": "Id",
           "type": "string"
         }
       },
@@ -30,243 +44,213 @@
         "name_short_en",
         "name_official",
         "iso3",
-        "iso2"
-      ]
+        "iso2",
+        "iso3166_2",
+        "id"
+      ],
+      "title": "CountryMetadata",
+      "type": "object"
     },
     "DataPublisher": {
-      "title": "DataPublisher",
-      "type": "object",
       "properties": {
         "name": {
-          "title": "Name",
           "description": "The name of the organisation publishing the data",
+          "title": "Name",
           "type": "string"
         },
         "url": {
-          "title": "Url",
           "description": "The url of the publisher's homepage.",
+          "title": "Url",
           "type": "string"
         },
         "description": {
-          "title": "Description",
           "description": "A brief description of the organisation publishing the data, including its mandate.",
+          "title": "Description",
           "type": "string"
         },
         "countries_of_interest": {
-          "title": "Countries Of Interest",
-          "description": "A list of countries for which the publisher has data available.",
-          "type": "array",
+          "description": "A list of country IDs for which the publisher has data available.",
           "items": {
-            "$ref": "#/definitions/CountryMetadata"
-          }
-        }
-      },
-      "required": [
-        "name",
-        "url",
-        "description",
-        "countries_of_interest"
-      ]
-    },
-    "SourceDataRelease": {
-      "title": "SourceDataRelease",
-      "type": "object",
-      "properties": {
-        "name": {
-          "title": "Name",
-          "description": "The name of the data release, as given by the publisher",
-          "type": "string"
+            "type": "string"
+          },
+          "title": "Countries Of Interest",
+          "type": "array"
         },
         "id": {
+          "readOnly": true,
           "title": "Id",
-          "description": "A unique identifier for the data release. This should be unique across all data releases from all publishers, but it is the client's responsibility to enforce this. If not specified, a UUID will be generated.",
           "type": "string"
-        },
-        "date_published": {
-          "title": "Date Published",
-          "description": "The date on which the data was published",
-          "type": "string",
-          "format": "date"
-        },
-        "reference_period": {
-          "title": "Reference Period",
-          "description": "The range of time for which the data can be assumed to be valid. Should be in the format (start_date, end_date). If the data represents a single day snapshot, end_date should be `None`.",
-          "type": "array",
-          "minItems": 2,
-          "maxItems": 2,
-          "items": [
-            {
-              "type": "string",
-              "format": "date"
-            },
-            {
-              "type": "string",
-              "format": "date"
-            }
-          ]
-        },
-        "collection_period": {
-          "title": "Collection Period",
-          "description": "The range of time during which the data was collected. Should be in the format (start_date, end_date). If the data represents a single day snapshot, end_date should be `None`.",
-          "type": "array",
-          "minItems": 2,
-          "maxItems": 2,
-          "items": [
-            {
-              "type": "string",
-              "format": "date"
-            },
-            {
-              "type": "string",
-              "format": "date"
-            }
-          ]
-        },
-        "expect_next_update": {
-          "title": "Expect Next Update",
-          "description": "The date on which is it expected that an updated edition of the data will be published. In same cases this will be the same as the `reference_period[1]`.",
-          "type": "string",
-          "format": "date"
-        },
-        "url": {
-          "title": "Url",
-          "description": "The url of the data release.",
-          "type": "string"
-        },
-        "publishing_organisation": {
-          "title": "Publishing Organisation",
-          "description": "The publisher of the data",
-          "allOf": [
-            {
-              "$ref": "#/definitions/DataPublisher"
-            }
-          ]
-        },
-        "description": {
-          "title": "Description",
-          "description": "A description of the data release",
-          "type": "string"
-        },
-        "geography_file": {
-          "title": "Geography File",
-          "description": "The path of the geography file",
-          "type": "string"
-        },
-        "geography_level": {
-          "title": "Geography Level",
-          "description": "The level of the geography",
-          "type": "string"
-        },
-        "countries_of_interest": {
-          "title": "Countries Of Interest",
-          "description": "A list of the countries for which the data is available",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/CountryMetadata"
-          }
-        },
-        "available_metrics":{
-          "title":"The metrics from this data source",
-          "description":"A list of metrics that are provided by this source",
-          "type":"array",
-          "items":{
-            "$ref":"#/definitions/MetricMetadata"
-          }
         }
       },
       "required": [
         "name",
-        "date_published",
-        "reference_period",
-        "collection_period",
-        "expect_next_update",
         "url",
-        "publishing_organisation",
         "description",
-        "geography_file",
-        "geography_level",
-        "countries_of_interest"
-      ]
+        "countries_of_interest",
+        "id"
+      ],
+      "title": "DataPublisher",
+      "type": "object"
     },
-    "MetricMetadata": {
-      "title": "MetricMetadata",
-      "type": "object",
+    "GeometryMetadata": {
       "properties": {
-        "human_readable_name": {
-          "title": "Human Readable Name",
-          "description": "A human readable name for the metric, something like \"Total Population under 12 years old\"",
+        "validity_period_start": {
+          "description": "The start of the range of time for which the regions are valid (inclusive)",
+          "format": "date",
+          "title": "Validity Period Start",
           "type": "string"
         },
-        "source_metric_id": {
-          "title": "Source Metric Id",
-          "description": "The name of the metric that comes from the source dataset ( for example in the ACS this might be \"B001_E001\" or something similar",
+        "validity_period_end": {
+          "description": "The end of the range of time for which the regions are valid (inclusive). If the data is a single-day snapshot, this should be the same as `validity_period_start`.",
+          "format": "date",
+          "title": "Validity Period End",
           "type": "string"
         },
-        "description": {
-          "title": "Description",
-          "description": "A longer description of the metric which might include info on the caveats for the metric",
+        "level": {
+          "description": "The geography level contained in the file (e.g. output area, LSOA, MSOA, etc)",
+          "title": "Level",
           "type": "string"
         },
         "hxl_tag": {
+          "description": "Humanitarian eXchange Language (HXL) description for the geography level",
           "title": "Hxl Tag",
-          "description": "Field description using the Humanitarian eXchange Language (HXL) standard",
           "type": "string"
         },
-        "metric_parquet_file_url": {
-          "title": "Metric Parquet File Url",
-          "description": "The relative path output file that contains this metric value. This should be relative to the root of a base URL defined at project level and should NOT include the file extension",
+        "id": {
+          "readOnly": true,
+          "title": "Id",
+          "type": "string"
+        },
+        "filename_stem": {
+          "readOnly": true,
+          "title": "Filename Stem",
+          "type": "string"
+        }
+      },
+      "required": [
+        "validity_period_start",
+        "validity_period_end",
+        "level",
+        "hxl_tag",
+        "id",
+        "filename_stem"
+      ],
+      "title": "GeometryMetadata",
+      "type": "object"
+    },
+    "MetricMetadata": {
+      "properties": {
+        "human_readable_name": {
+          "description": "A human readable name for the metric, something like \"Total Population under 12 years old\"",
+          "title": "Human Readable Name",
+          "type": "string"
+        },
+        "source_metric_id": {
+          "description": "The name of the metric that comes from the source dataset (for example in the ACS this might be \"B001_E001\" or something similar)",
+          "title": "Source Metric Id",
+          "type": "string"
+        },
+        "description": {
+          "description": "A longer description of the metric which might include info on the caveats for the metric",
+          "title": "Description",
+          "type": "string"
+        },
+        "hxl_tag": {
+          "description": "Field description using the Humanitarian eXchange Language (HXL) standard",
+          "title": "Hxl Tag",
+          "type": "string"
+        },
+        "metric_parquet_path": {
+          "description": "The path to the parquet file that contains the metric",
+          "title": "Metric Parquet Path",
           "type": "string"
         },
         "parquet_column_name": {
-          "title": "Parquet Column Name",
           "description": "Name of column in the outputted parquet file which contains the metric",
+          "title": "Parquet Column Name",
           "type": "string"
         },
         "parquet_margin_of_error_column": {
-          "title": "Parquet Margin Of Error Column",
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
           "description": "Name of the column if any that contains the margin of error for the metric",
-          "union_mode": "smart",
-          "type": "string"
+          "title": "Parquet Margin Of Error Column"
         },
         "parquet_margin_of_error_file": {
-          "title": "Parquet Margin Of Error File",
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
           "description": "Location (url) of the parquet file that contains the margin of error for the metric",
-          "union_mode": "smart",
-          "type": "string"
+          "title": "Parquet Margin Of Error File"
         },
         "potential_denominator_ids": {
-          "title": "Potential Denominator Ids",
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
           "description": "A list of metrics which are suitable denominators for this metric.",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+          "title": "Potential Denominator Ids"
         },
         "parent_metric_id": {
-          "title": "Parent Metric Id",
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
           "description": "Metric if any which is the parent to this one ( some census data like the ACS is organised hierarchically, this can be useful for making the metadata more searchable)",
-          "union_mode": "smart",
-          "type": "string"
+          "title": "Parent Metric Id"
         },
         "source_data_release_id": {
-          "title": "Source Data Release Id",
           "description": "The id of the data release from which this metric comes",
+          "title": "Source Data Release Id",
           "type": "string"
         },
         "source_download_url": {
-          "title": "Source Download Url",
           "description": "The url used to download the data from source.",
+          "title": "Source Download Url",
           "type": "string"
         },
         "source_archive_file_path": {
-          "title": "Source Archive File Path",
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
           "description": "(Optional), If the downloaded data is in an archive file (eg zip, tar, etc), this field is the path with the archive to locate the data file.",
-          "union_mode": "smart",
-          "type": "string"
+          "title": "Source Archive File Path"
         },
         "source_documentation_url": {
-          "title": "Source Documentation Url",
           "description": "The documentation of the data release in human readable form.",
+          "title": "Source Documentation Url",
+          "type": "string"
+        },
+        "id": {
+          "readOnly": true,
+          "title": "Id",
           "type": "string"
         }
       },
@@ -275,9 +259,108 @@
         "source_metric_id",
         "description",
         "hxl_tag",
-        "parquet_column_name"
-      ]
+        "metric_parquet_path",
+        "parquet_column_name",
+        "parquet_margin_of_error_column",
+        "parquet_margin_of_error_file",
+        "potential_denominator_ids",
+        "parent_metric_id",
+        "source_data_release_id",
+        "source_download_url",
+        "source_archive_file_path",
+        "source_documentation_url",
+        "id"
+      ],
+      "title": "MetricMetadata",
+      "type": "object"
+    },
+    "SourceDataRelease": {
+      "properties": {
+        "name": {
+          "description": "The name of the data release, as given by the publisher",
+          "title": "Name",
+          "type": "string"
+        },
+        "date_published": {
+          "description": "The date on which the data was published",
+          "format": "date",
+          "title": "Date Published",
+          "type": "string"
+        },
+        "reference_period_start": {
+          "description": "The start of the range of time for which the data can be assumed to be valid (inclusive)",
+          "format": "date",
+          "title": "Reference Period Start",
+          "type": "string"
+        },
+        "reference_period_end": {
+          "description": "The end of the range of time for which the data can be assumed to be valid (inclusive). If the data is a single-day snapshot, this should be the same as `reference_period_start`.",
+          "format": "date",
+          "title": "Reference Period End",
+          "type": "string"
+        },
+        "collection_period_start": {
+          "description": "The start of the range of time during which the data was collected (inclusive)",
+          "format": "date",
+          "title": "Collection Period Start",
+          "type": "string"
+        },
+        "collection_period_end": {
+          "description": "The end of the range of time during which the data was collected (inclusive). If the data were collected in a single day, this should be the same as `collection_period_start`.",
+          "format": "date",
+          "title": "Collection Period End",
+          "type": "string"
+        },
+        "expect_next_update": {
+          "description": "The date on which is it expected that an updated edition of the data will be published. In some cases this will be the same as `reference_period_end`",
+          "format": "date",
+          "title": "Expect Next Update",
+          "type": "string"
+        },
+        "url": {
+          "description": "The url of the data release.",
+          "title": "Url",
+          "type": "string"
+        },
+        "data_publisher_id": {
+          "description": "The ID of the publisher of the data release",
+          "title": "Data Publisher Id",
+          "type": "string"
+        },
+        "description": {
+          "description": "A description of the data release",
+          "title": "Description",
+          "type": "string"
+        },
+        "geometry_metadata_id": {
+          "description": "The ID of the geometry metadata associated with this data release",
+          "title": "Geometry Metadata Id",
+          "type": "string"
+        },
+        "id": {
+          "readOnly": true,
+          "title": "Id",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "date_published",
+        "reference_period_start",
+        "reference_period_end",
+        "collection_period_start",
+        "collection_period_end",
+        "expect_next_update",
+        "url",
+        "data_publisher_id",
+        "description",
+        "geometry_metadata_id",
+        "id"
+      ],
+      "title": "SourceDataRelease",
+      "type": "object"
     }
   },
-  "version": "0.1.0"
+  "title": "popgetter_schema",
+  "description": "Version 0.1.0"
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -5,7 +5,7 @@ use clap::{Args, Parser, Subcommand};
 use enum_dispatch::enum_dispatch;
 use log::{debug, info};
 use popgetter::{
-    data_request_spec::{BBox, DataRequestSpec, GeometrySpec, MetricSpec, RegionSpec}, formatters::{CSVFormatter, GeoJSONFormatter, GeoJSONSeqFormatter, OutputFormatter, OutputGenerator}, metadata::MetricId, Popgetter
+    config::Config, data_request_spec::{BBox, DataRequestSpec, GeometrySpec, MetricSpec, RegionSpec}, formatters::{CSVFormatter, GeoJSONFormatter, GeoJSONSeqFormatter, OutputFormatter, OutputGenerator}, metadata::MetricId, Popgetter
 };
 use serde::{Deserialize, Serialize};
 use std::fs::File;
@@ -25,7 +25,7 @@ pub enum OutputFormat {
 /// Trait that defines what to run when a given subcommand is invoked.
 #[enum_dispatch]
 pub trait RunCommand {
-    async fn run(&self) -> Result<()>;
+    async fn run(&self, config: Config) -> Result<()>;
 }
 
 /// The Data command is the one we invoke to get a set of metrics and geometry
@@ -89,16 +89,14 @@ impl DataCommand{
         } 
 
         metric_ids
-
-    
     }
 }
 
 impl RunCommand for DataCommand {
-    async fn run(&self) -> Result<()> {
+    async fn run(&self, config: Config) -> Result<()> {
         info!("Running `data` subcommand");
 
-        let popgetter = Popgetter::new().await?;
+        let popgetter = Popgetter::new_with_config(config).await?;
         let data_request = DataRequestSpec::from(self);
         let mut results = popgetter.get_data_request(&data_request).await?;
 
@@ -152,7 +150,7 @@ pub struct MetricsCommand {
 }
 
 impl RunCommand for MetricsCommand {
-    async fn run(&self) -> Result<()> {
+    async fn run(&self, config: Config) -> Result<()> {
         info!("Running `metrics` subcommand");
         Ok(())
     }
@@ -164,8 +162,8 @@ impl RunCommand for MetricsCommand {
 pub struct CountriesCommand;
 
 impl RunCommand for CountriesCommand {
-    async fn run(&self) -> Result<()> {
-        let _popgetter = Popgetter::new().await?;
+    async fn run(&self, config: Config) -> Result<()> {
+        let _popgetter = Popgetter::new_with_config(config).await?;
         Ok(())
     }
 }
@@ -176,7 +174,7 @@ impl RunCommand for CountriesCommand {
 pub struct SurveysCommand;
 
 impl RunCommand for SurveysCommand {
-    async fn run(&self) -> Result<()> {
+    async fn run(&self, config: Config) -> Result<()> {
         info!("Running `surveys` subcommand");
         Ok(())
     }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -127,7 +127,7 @@ impl From<&DataCommand> for DataRequestSpec {
 
         let metrics = value.gather_metric_requests()
                            .into_iter()
-                           .map(|metric_id| MetricSpec::Metric(metric_id))
+                           .map(MetricSpec::Metric)
                            .collect();
 
         DataRequestSpec {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -9,6 +9,7 @@ use popgetter::{
 use serde::{Deserialize, Serialize};
 use std::fs::File;
 use strum_macros::EnumString;
+use log::{info,debug};
 
 /// Defines the output formats we are able to produce data in.
 #[derive(Clone, Debug, Deserialize, Serialize, EnumString, PartialEq, Eq)]
@@ -52,6 +53,8 @@ pub struct DataCommand {
 
 impl RunCommand for DataCommand {
     async fn run(&self) -> Result<()> {
+        info!("Running `data` subcommand");
+
         let popgetter = Popgetter::new()?;
         let data_request = DataRequestSpec::from(self);
         let mut results = popgetter.get_data_request(&data_request).await?;
@@ -69,7 +72,7 @@ impl RunCommand for DataCommand {
             _=>todo!("output format not implemented")
         };
 
-        println!("{results:#?}");
+        debug!("{results:#?}");
         let mut f = File::create(&self.output_file)?;
         formatter.save(&mut f,&mut results)?;
 
@@ -116,7 +119,7 @@ pub struct MetricsCommand {
 
 impl RunCommand for MetricsCommand {
     async fn run(&self) -> Result<()> {
-        println!("Running Metrics Command");
+        info!("Running `metrics` subcommand");
         Ok(())
     }
 }
@@ -128,7 +131,7 @@ pub struct CountriesCommand;
 
 impl RunCommand for CountriesCommand {
     async fn run(&self) -> Result<()> {
-        println!("Running Countries Command");
+        info!("Running `countries` subcommand");
         Ok(())
     }
 }
@@ -140,7 +143,7 @@ pub struct SurveysCommand;
 
 impl RunCommand for SurveysCommand {
     async fn run(&self) -> Result<()> {
-        println!("Running Surveys Command");
+        info!("Running `surveys` subcommand");
         Ok(())
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -5,7 +5,6 @@ use clap::{Args, Parser, Subcommand};
 use enum_dispatch::enum_dispatch;
 use log::{debug, info};
 use popgetter::{
-    config::Config,
     data_request_spec::{BBox, DataRequestSpec, GeometrySpec, MetricSpec, RegionSpec},
     formatters::{
         CSVFormatter, GeoJSONFormatter, GeoJSONSeqFormatter, OutputFormatter, OutputGenerator,
@@ -30,7 +29,7 @@ pub enum OutputFormat {
 /// Trait that defines what to run when a given subcommand is invoked.
 #[enum_dispatch]
 pub trait RunCommand {
-    async fn run(&self, config: &Config) -> Result<()>;
+    async fn run(&self) -> Result<()>;
 }
 
 /// The Data command is the one we invoke to get a set of metrics and geometry
@@ -57,10 +56,10 @@ pub struct DataCommand {
 }
 
 impl RunCommand for DataCommand {
-    async fn run(&self, config: &Config) -> Result<()> {
+    async fn run(&self) -> Result<()> {
         info!("Running `data` subcommand");
 
-        let popgetter = Popgetter::new(config).await?;
+        let popgetter = Popgetter::new().await?;
         let data_request = DataRequestSpec::from(self);
         let mut results = popgetter.get_data_request(&data_request).await?;
 
@@ -117,7 +116,7 @@ pub struct MetricsCommand {
 }
 
 impl RunCommand for MetricsCommand {
-    async fn run(&self, _config: &Config) -> Result<()> {
+    async fn run(&self) -> Result<()> {
         info!("Running `metrics` subcommand");
         Ok(())
     }
@@ -129,8 +128,8 @@ impl RunCommand for MetricsCommand {
 pub struct CountriesCommand;
 
 impl RunCommand for CountriesCommand {
-    async fn run(&self, config: &Config) -> Result<()> {
-        let _popgetter = Popgetter::new(config).await?;
+    async fn run(&self) -> Result<()> {
+        let _popgetter = Popgetter::new().await?;
         Ok(())
     }
 }
@@ -141,7 +140,7 @@ impl RunCommand for CountriesCommand {
 pub struct SurveysCommand;
 
 impl RunCommand for SurveysCommand {
-    async fn run(&self, _config: &Config) -> Result<()> {
+    async fn run(&self) -> Result<()> {
         info!("Running `surveys` subcommand");
         Ok(())
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,43 +1,14 @@
 #[derive(Debug)]
 pub struct Config {
     pub base_path: String,
-    http_client: reqwest::Client,
 }
 
 pub fn init() -> Config {
     let default_base_path: String =
         "https://popgetter.blob.core.windows.net/popgetter-dagster-test/test_2".into();
     let base_path = std::env::var("POPGETTER_CLI_BASE_PATH").unwrap_or(default_base_path);
-    let http_client = reqwest::Client::new();
 
     Config {
         base_path,
-        http_client,
-    }
-}
-
-impl Config {
-    // TODO hacky
-    fn base_path_is_internet(&self) -> bool {
-        self.base_path.starts_with("http")
-    }
-
-    // TODO use PopgetterError instead of anyhow
-    // Read in a text file either using the local filesystem or http
-    pub async fn get_text_file(&self, rel_path: &str) -> Result<String, anyhow::Error> {
-        let full_path = format!("{}/{}", self.base_path, rel_path);
-        if self.base_path_is_internet() {
-            self.http_client
-                .get(&full_path)
-                .send()
-                .await
-                .map_err(|e| anyhow::anyhow!("Failed to fetch file '{}': {}", &full_path, e))?
-                .text()
-                .await
-                .map_err(|e| anyhow::anyhow!("Failed to read file '{}': {}", &full_path, e))
-        } else {
-            std::fs::read_to_string(&full_path)
-                .map_err(|e| anyhow::anyhow!("Failed to read file '{}': {}", &full_path, e))
-        }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,43 @@
+#[derive(Debug)]
+pub struct Config {
+    pub base_path: String,
+    http_client: reqwest::Client,
+}
+
+pub fn init() -> Config {
+    let default_base_path: String =
+        "https://popgetter.blob.core.windows.net/popgetter-dagster-test/test_2".into();
+    let base_path = std::env::var("POPGETTER_CLI_BASE_PATH").unwrap_or(default_base_path);
+    let http_client = reqwest::Client::new();
+
+    Config {
+        base_path,
+        http_client,
+    }
+}
+
+impl Config {
+    // TODO hacky
+    fn base_path_is_internet(&self) -> bool {
+        self.base_path.starts_with("http")
+    }
+
+    // TODO use PopgetterError instead of anyhow
+    // Read in a text file either using the local filesystem or http
+    pub async fn get_text_file(&self, rel_path: &str) -> Result<String, anyhow::Error> {
+        let full_path = format!("{}/{}", self.base_path, rel_path);
+        if self.base_path_is_internet() {
+            self.http_client
+                .get(&full_path)
+                .send()
+                .await
+                .map_err(|e| anyhow::anyhow!("Failed to fetch file '{}': {}", &full_path, e))?
+                .text()
+                .await
+                .map_err(|e| anyhow::anyhow!("Failed to read file '{}': {}", &full_path, e))
+        } else {
+            std::fs::read_to_string(&full_path)
+                .map_err(|e| anyhow::anyhow!("Failed to read file '{}': {}", &full_path, e))
+        }
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,25 +15,3 @@ impl Default for Config {
         }
     }
 }
-
-impl Config {
-    fn xdg_config_path() -> PathBuf {
-        let xdg_dirs = xdg::BaseDirectories::with_prefix("popgetter").unwrap();
-        xdg_dirs.place_config_file("config.toml").unwrap()
-    }
-
-    pub fn from_toml() -> Self {
-        let file_path = Self::xdg_config_path();
-
-        match std::fs::read_to_string(file_path) {
-            Ok(contents) => toml::from_str(&contents).expect("Invalid TOML in config file"),
-            Err(e) => {
-                if e.kind() == std::io::ErrorKind::NotFound {
-                    Config::default()
-                } else {
-                    panic!("Error reading config file: {:#?}", e);
-                }
-            }
-        }
-    }
-}

--- a/src/data_request_spec.rs
+++ b/src/data_request_spec.rs
@@ -14,7 +14,6 @@ use std::{
     ops::{Index, IndexMut},
     str::FromStr,
 };
-use log::debug;
 
 use crate::{
     metadata::{Metadata, MetricId},

--- a/src/data_request_spec.rs
+++ b/src/data_request_spec.rs
@@ -4,6 +4,7 @@ use std::{
     ops::{Index, IndexMut},
     str::FromStr,
 };
+use log::debug;
 
 use crate::{metadata::Metadata, parquet::MetricRequest};
 
@@ -19,7 +20,7 @@ impl DataRequestSpec {
     /// and a catalouge.
     pub fn metric_requests(&self, catalogue: &Metadata) -> Result<Vec<MetricRequest>> {
         let mut metric_requests: Vec<MetricRequest> = vec![];
-        println!("Try to get metrics {:#?}", self.metrics);
+        debug!("Try to get metrics {:#?}", self.metrics);
         for metric_spec in &self.metrics {
             match metric_spec {
                 MetricSpec::NamedMetric(name) => {

--- a/src/data_request_spec.rs
+++ b/src/data_request_spec.rs
@@ -122,12 +122,12 @@ mod tests {
         let bbox = BBox::from_str("0.0,1.0,2.0");
         assert!(
             bbox.is_err(),
-            "A string with fewer than 4 coords should parse"
+            "A string with fewer than 4 coords should not parse"
         );
         let bbox = BBox::from_str("0.0,1.0,2.0,3.0,4.0");
         assert!(
             bbox.is_err(),
-            "A string with fewer than 5 coords should parse"
+            "A string with 5 or more coords should not parse"
         );
         let bbox = BBox::from_str("0.0sdfsd,1.0,2.0");
         assert!(bbox.is_err(), "A string with letters shouldn't parse");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,9 @@ use polars::{frame::DataFrame, prelude::DataFrameJoinOps};
 use tokio::try_join;
 use log::debug;
 
+use crate::config::Config;
 use crate::geo::get_geometries;
+pub mod config;
 pub mod data_request_spec;
 pub mod geo;
 pub mod metadata;
@@ -21,8 +23,8 @@ pub struct Popgetter {
 
 impl Popgetter {
     /// Setup the Popgetter object 
-    pub fn new() -> Result<Self> {
-        let metadata = metadata::load_all(&["be"])?;
+    pub async fn new(config: &Config) -> Result<Self> {
+        let metadata = metadata::load_all(config).await?;
         Ok(Self { metadata })
     }
 
@@ -51,4 +53,3 @@ impl Popgetter {
         Ok(result)
     }
 }
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@ pub struct Popgetter {
 impl Popgetter {
     /// Setup the Popgetter object
     pub async fn new() -> Result<Self> {
-        let config = config::init();
+        let config = Config::from_toml();
         debug!("config: {config:?}");
         let metadata = metadata::load_all(&config).await?;
         Ok(Self { metadata, config })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,10 @@
 use anyhow::Result;
 use data_request_spec::DataRequestSpec;
+use log::debug;
 use metadata::Metadata;
 use parquet::get_metrics;
 use polars::{frame::DataFrame, prelude::DataFrameJoinOps};
 use tokio::try_join;
-use log::debug;
 
 use crate::config::Config;
 use crate::geo::get_geometries;
@@ -14,42 +14,46 @@ pub mod geo;
 pub mod metadata;
 pub mod parquet;
 
-#[cfg(feature="formatters")]
+#[cfg(feature = "formatters")]
 pub mod formatters;
 
 pub struct Popgetter {
     pub metadata: Metadata,
+    pub config: Config,
 }
 
 impl Popgetter {
-    /// Setup the Popgetter object 
-    pub async fn new(config: &Config) -> Result<Self> {
-        let metadata = metadata::load_all(config).await?;
-        Ok(Self { metadata })
+    /// Setup the Popgetter object
+    pub async fn new() -> Result<Self> {
+        let config = config::init();
+        debug!("config: {config:?}");
+        let metadata = metadata::load_all(&config).await?;
+        Ok(Self { metadata, config })
     }
 
-    // Given a Data Request Spec 
-    // Return a DataFrame of the selected dataset 
+    // Given a Data Request Spec
+    // Return a DataFrame of the selected dataset
     pub async fn get_data_request(&self, data_request: &DataRequestSpec) -> Result<DataFrame> {
         let metric_requests = data_request.metric_requests(&self.metadata)?;
         let geom_file = data_request.geom_details(&self.metadata)?;
 
         // Required because polars is blocking
-        let metrics = tokio::task::spawn_blocking(move || {
-            get_metrics(&metric_requests,None)
-        });
+        let metrics = tokio::task::spawn_blocking(move || get_metrics(&metric_requests, None));
 
         // TODO The custom geoid here is because of the legacy US code
         // This should be standardized on future pipeline outputs
         let geoms = get_geometries(&geom_file, None, Some("AFFGEOID".into()));
 
-        // try_join requires us to have the errors from all futures be the same. 
+        // try_join requires us to have the errors from all futures be the same.
         // We use anyhow to get it back properly
-        let (metrics,geoms) = try_join!(async move { metrics.await.map_err(anyhow::Error::from)}, geoms)?;
+        let (metrics, geoms) = try_join!(
+            async move { metrics.await.map_err(anyhow::Error::from) },
+            geoms
+        )?;
         debug!("geoms: {geoms:#?}");
         debug!("metrics: {metrics:#?}");
-        
-        let result =geoms.inner_join(&metrics?,["GEOID"],["GEO_ID"])?; 
+
+        let result = geoms.inner_join(&metrics?, ["GEOID"], ["GEO_ID"])?;
         Ok(result)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ use metadata::Metadata;
 use parquet::get_metrics;
 use polars::{frame::DataFrame, prelude::DataFrameJoinOps};
 use tokio::try_join;
+use log::debug;
 
 use crate::geo::get_geometries;
 pub mod data_request_spec;
@@ -43,8 +44,8 @@ impl Popgetter {
         // try_join requires us to have the errors from all futures be the same. 
         // We use anyhow to get it back properly
         let (metrics,geoms) = try_join!(async move { metrics.await.map_err(anyhow::Error::from)}, geoms)?;
-        println!("geoms {geoms:#?}");
-        println!("metrics {metrics:#?}");
+        debug!("geoms: {geoms:#?}");
+        debug!("metrics: {metrics:#?}");
         
         let result =geoms.inner_join(&metrics?,["GEOID"],["GEO_ID"])?; 
         Ok(result)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,9 +23,13 @@ pub struct Popgetter {
 }
 
 impl Popgetter {
-    /// Setup the Popgetter object
+    /// Setup the Popgetter object with default configuration
     pub async fn new() -> Result<Self> {
-        let config = Config::from_toml();
+        Self::new_with_config(Config::default()).await
+    }
+
+    /// Setup the Popgetter object with custom configuration
+    pub async fn new_with_config(config: Config) -> Result<Self> {
         debug!("config: {config:?}");
         let metadata = metadata::load_all(&config).await?;
         Ok(Self { metadata, config })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@ use parquet::get_metrics;
 use polars::{frame::DataFrame, prelude::DataFrameJoinOps};
 use tokio::try_join;
 
-use crate::{config::Config, data_request_spec::MetricSpec, geo::get_geometries};
+use crate::{config::Config, geo::get_geometries};
 pub mod config;
 pub mod data_request_spec;
 pub mod geo;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,10 +3,15 @@ mod cli;
 use anyhow::Result;
 use clap::Parser;
 use cli::{Cli, RunCommand};
+use log::debug;
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    pretty_env_logger::init_timed();
+
     let args = Cli::parse();
+    debug!("args: {args:?}");
+
     if let Some(command) = args.command {
         command.run().await?;
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,16 +4,20 @@ use anyhow::Result;
 use clap::Parser;
 use cli::{Cli, RunCommand};
 use log::debug;
+use popgetter::config;
 
 #[tokio::main]
 async fn main() -> Result<()> {
     pretty_env_logger::init_timed();
 
+    let config = config::init();
+    debug!("config: {config:?}");
+
     let args = Cli::parse();
     debug!("args: {args:?}");
 
     if let Some(command) = args.command {
-        command.run().await?;
+        command.run(&config).await?;
     }
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,17 +3,38 @@ mod cli;
 use anyhow::Result;
 use clap::Parser;
 use cli::{Cli, RunCommand};
+use popgetter::config::Config;
 use log::debug;
 
 #[tokio::main]
 async fn main() -> Result<()> {
     pretty_env_logger::init_timed();
-
+    
     let args = Cli::parse();
     debug!("args: {args:?}");
+    let config: Config = read_config_from_toml();
+    debug!("config: {config:?}");
 
     if let Some(command) = args.command {
-        command.run().await?;
+        command.run(config).await?;
     }
     Ok(())
+}
+
+
+fn read_config_from_toml() -> Config {
+    // macOS: ~/.config/popgetter/config.toml
+    let xdg_dirs = xdg::BaseDirectories::with_prefix("popgetter").unwrap();
+    let file_path = xdg_dirs.place_config_file("config.toml").unwrap();
+
+    match std::fs::read_to_string(file_path) {
+        Ok(contents) => toml::from_str(&contents).expect("Invalid TOML in config file"),
+        Err(e) => {
+            if e.kind() == std::io::ErrorKind::NotFound {
+                Config::default()
+            } else {
+                panic!("Error reading config file: {:#?}", e);
+            }
+        }
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,20 +4,16 @@ use anyhow::Result;
 use clap::Parser;
 use cli::{Cli, RunCommand};
 use log::debug;
-use popgetter::config;
 
 #[tokio::main]
 async fn main() -> Result<()> {
     pretty_env_logger::init_timed();
 
-    let config = config::init();
-    debug!("config: {config:?}");
-
     let args = Cli::parse();
     debug!("args: {args:?}");
 
     if let Some(command) = args.command {
-        command.run(&config).await?;
+        command.run().await?;
     }
     Ok(())
 }

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -230,18 +230,12 @@ impl CountryMetadataLoader {
     /// Load the Metadata catalouge for this country with
     /// the specified metadata paths
     pub async fn load(self, config: &Config) -> Result<Metadata> {
-        let metrics_future = self.load_metadata(&self.paths.metrics, config);
-        let geometries_future = self.load_metadata(&self.paths.geometry, config);
-        let source_data_future = self.load_metadata(&self.paths.source_data, config);
-        let data_publishers_future = self.load_metadata(&self.paths.data_publishers, config);
-        let countries_future = self.load_metadata(&self.paths.country, config);
-
         let t = try_join!(
-            metrics_future,
-            geometries_future,
-            source_data_future,
-            data_publishers_future,
-            countries_future
+            self.load_metadata(&self.paths.metrics, config),
+            self.load_metadata(&self.paths.geometry, config),
+            self.load_metadata(&self.paths.source_data, config),
+            self.load_metadata(&self.paths.data_publishers, config),
+            self.load_metadata(&self.paths.country, config),
         )?;
         Ok(Metadata {
             metrics: t.0,

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -279,19 +279,18 @@ pub async fn load_all(config: &Config) -> Result<Metadata> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config;
 
-    #[test]
-    fn country_metadata_should_load() {
-        let config = config::init();
-        let metadata = CountryMetadataLoader::new("be").load(&config);
+    #[tokio::test]
+    async fn country_metadata_should_load() {
+        let config = Config::default();
+        let metadata = CountryMetadataLoader::new("be").load(&config).await;
         println!("{metadata:#?}");
         assert!(metadata.is_ok(), "Data should have loaded ok");
     }
 
     #[tokio::test]
     async fn all_metadata_should_load() {
-        let config = config::init();
+        let config = Config::default();
         let metadata = load_all(&config).await;
         println!("{metadata:#?}");
         assert!(metadata.is_ok(), "Data should have loaded ok");
@@ -299,7 +298,7 @@ mod tests {
 
     #[tokio::test]
     async fn we_should_be_able_to_find_metadata_by_id() {
-        let config = config::init();
+        let config = Config::default();
         let metadata = load_all(&config).await.unwrap();
         let metrics =
             metadata.get_metric_details("#population+children+age0_17", "municipality", "2022");

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -8,6 +8,7 @@ use polars::{
     prelude::{lit, JoinArgs, JoinType, UnionArgs},
 };
 use std::default::Default;
+use log::info;
 
 use crate::parquet::MetricRequest;
 
@@ -172,7 +173,7 @@ impl CountryMetadataLoader {
     fn load_metadata(&self, path: &str) -> Result<DataFrame> {
         let url = format!("{}/{}/{path}", self.paths.base_url, self.country);
         let args = ScanArgsParquet::default();
-        println!("Attempting to load {url}");
+        info!("Attempting to load {url}");
         let df: DataFrame = LazyFrame::scan_parquet(url, args)?.collect()?;
         Ok(df)
     }

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -187,8 +187,12 @@ impl CountryMetadataLoader {
 /// Load the metadata for a list of countries and merge them into
 /// a single `Metadata` catalouge.
 pub async fn load_all(config: &Config) -> Result<Metadata> {
-    let country_names: Vec<String> = config
-        .get_text_file("countries.txt")
+    let country_text_file = format!("{}/countries.txt", config.base_path);
+    let country_names: Vec<String> = reqwest::Client::new()
+        .get(&country_text_file)
+        .send()
+        .await?
+        .text()
         .await?
         .lines()
         .map(|s| s.to_string())

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -376,7 +376,7 @@ mod tests {
     #[tokio::test]
     async fn metric_ids_should_expand_properly() {
         let config = Config::default();
-        let metadata = load_all(&config).await?;
+        let metadata = load_all(&config).await.unwrap();
         let expanded_metrics =
             metadata.expand_wildcard_metric(&MetricId::Hxl("population-*".into()));
         assert!(
@@ -414,7 +414,7 @@ mod tests {
     #[tokio::test]
     async fn human_readable_metric_ids_should_expand_properly() {
         let config = Config::default();
-        let metadata = CountryMetadataLoader::new("be").load(&config).await?;
+        let metadata = CountryMetadataLoader::new("be").load(&config).await.unwrap();
         let expanded_metrics =
             metadata.expand_wildcard_metric(&MetricId::CommonName("Children*".into()));
 
@@ -448,7 +448,7 @@ mod tests {
     #[tokio::test]
     async fn fully_defined_metric_ids_should_expand_to_itself() {
         let config = Config::default();
-        let metadata = CountryMetadataLoader::new("be").load(&config).await?;
+        let metadata = CountryMetadataLoader::new("be").load(&config).await.unwrap();
         let expanded_metrics = metadata
             .expand_wildcard_metric(&MetricId::Hxl(r"#population\+infants\+age0\_4".into()));
         assert!(

--- a/src/search.rs
+++ b/src/search.rs
@@ -3,7 +3,7 @@
 use polars::lazy::dsl::{col, lit, Expr};
 use polars::frame::DataFrame;
 use serde::{Deserialize, Serialize};
-use crate::metadata::{MetricId, Metadata};
+use crate::metadata::Metadata;
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 enum SearchContext {


### PR DESCRIPTION
This PR:

- Introduces a `Config` struct which right now only contains a base_path URL
  - The config is loaded when the central `Popgetter` struct is initialised and then passed into the individual metadata fetching methods.
  - The config is loaded from `~/.config/popgetter/config.toml` (or the equivalent XDG path). If the file doesn't exist, uses the `Default` implementation.
- Reads in the list of countries from a top-level `countries.txt` file in the blob storage, rather than a hardcoded list of countries.
  - It's still unclear how we generate this file (I did it manually this time). This should be an upstream issue.
- Adds some basic logging
- Adds caching of Rust crates to speed up GHA builds
- I've also dealt with the merge conflicts from the `30-search-metadata` branch 🙂 

The key changes are in `src/config.rs` and `src/metadata.rs`, the rest is mostly fluff from cleaning up warnings etc

---------

old todolist

- [x] Remove http client, remove features for local file reading
   - As discussed on Monday 3 June, we only intend to support reading files from the Internet and not from the local filesystem. In the event where we want to work offline / develop quickly using data on the local filesystem, we should instead set up a HTTP server that simply serves that data
- [x] Refactor command run, only pass config into Popgetter struct
- [x] Add serde derives for Config
- ~~Figure out what kind of server supports range requests (`python -m http.server` doesn't do it)~~
  This is now #37