### PR TITLE
Serialisation aliases

### DIFF
--- a/src/column_names.rs
+++ b/src/column_names.rs
@@ -1,0 +1,59 @@
+//! This module stores the eventual column names of all the metadata classes, which are used when
+//! serialising the metadata to a dataframe. Note that this must be synchronised with column names
+//! defined in the upstream metadata classes!
+
+pub const GEO_ID: &str = "GEO_ID";
+
+pub const COUNTRY_ID: &str = "country_id";
+pub const COUNTRY_NAME_SHORT_EN: &str = "country_name_short_en";
+pub const COUNTRY_NAME_OFFICIAL: &str = "country_name_official";
+pub const COUNTRY_ISO3: &str = "country_iso3";
+pub const COUNTRY_ISO2: &str = "country_iso2";
+pub const COUNTRY_ISO3166_2: &str = "country_iso3166_2";
+
+pub const DATA_PUBLISHER_ID: &str = "data_publisher_id";
+pub const DATA_PUBLISHER_NAME: &str = "data_publisher_name";
+pub const DATA_PUBLISHER_URL: &str = "data_publisher_url";
+pub const DATA_PUBLISHER_DESCRIPTION: &str = "data_publisher_description";
+pub const DATA_PUBLISHER_COUNTRIES_OF_INTEREST: &str = "data_publisher_countries_of_interest";
+
+pub const GEOMETRY_ID: &str = "geometry_id";
+pub const GEOMETRY_FILEPATH_STEM: &str = "geometry_filepath_stem";
+pub const GEOMETRY_VALIDITY_PERIOD_START: &str = "geometry_validity_period_start";
+pub const GEOMETRY_VALIDITY_PERIOD_END: &str = "geometry_validity_period_end";
+pub const GEOMETRY_LEVEL: &str = "geometry_level";
+pub const GEOMETRY_HXL_TAG: &str = "geometry_hxl_tag";
+
+pub const SOURCE_DATA_RELEASE_ID: &str = "source_data_release_id";
+pub const SOURCE_DATA_RELEASE_NAME: &str = "source_data_release_name";
+pub const SOURCE_DATA_RELEASE_DATE_PUBLISHED: &str = "source_data_release_date_published";
+pub const SOURCE_DATA_RELEASE_REFERENCE_PERIOD_START: &str =
+    "source_data_release_reference_period_start";
+pub const SOURCE_DATA_RELEASE_REFERENCE_PERIOD_END: &str =
+    "source_data_release_reference_period_end";
+pub const SOURCE_DATA_RELEASE_COLLECTION_PERIOD_START: &str =
+    "source_data_release_collection_period_start";
+pub const SOURCE_DATA_RELEASE_COLLECTION_PERIOD_END: &str =
+    "source_data_release_collection_period_end";
+pub const SOURCE_DATA_RELEASE_EXPECT_NEXT_UPDATE: &str = "source_data_release_expect_next_update";
+pub const SOURCE_DATA_RELEASE_URL: &str = "source_data_release_url";
+pub const SOURCE_DATA_RELEASE_DATA_PUBLISHER_ID: &str = "source_data_release_data_publisher_id";
+pub const SOURCE_DATA_RELEASE_DESCRIPTION: &str = "source_data_release_description";
+pub const SOURCE_DATA_RELEASE_GEOMETRY_METADATA_ID: &str =
+    "source_data_release_geometry_metadata_id";
+
+pub const METRIC_ID: &str = "metric_id";
+pub const METRIC_HUMAN_READABLE_NAME: &str = "metric_human_readable_name";
+pub const METRIC_SOURCE_METRIC_ID: &str = "metric_source_id";
+pub const METRIC_DESCRIPTION: &str = "metric_description";
+pub const METRIC_HXL_TAG: &str = "metric_hxl_tag";
+pub const METRIC_PARQUET_PATH: &str = "metric_parquet_path";
+pub const METRIC_PARQUET_COLUMN_NAME: &str = "metric_parquet_column_name";
+pub const METRIC_PARQUET_MARGIN_OF_ERROR_COLUMN: &str = "metric_parquet_margin_of_error_column";
+pub const METRIC_PARQUET_MARGIN_OF_ERROR_FILE: &str = "metric_parquet_margin_of_error_file";
+pub const METRIC_POTENTIAL_DENOMINATOR_IDS: &str = "metric_potential_denominator_ids";
+pub const METRIC_PARENT_METRIC_ID: &str = "metric_parent_metric_id";
+pub const METRIC_SOURCE_DATA_RELEASE_ID: &str = "metric_source_data_release_id";
+pub const METRIC_SOURCE_DOWNLOAD_URL: &str = "metric_source_download_url";
+pub const METRIC_SOURCE_ARCHIVE_FILE_PATH: &str = "metric_source_archive_file_path";
+pub const METRIC_SOURCE_DOCUMENTATION_URL: &str = "metric_source_documentation_url";

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,8 +9,9 @@ pub struct Config {
 impl Default for Config {
     fn default() -> Self {
         Config {
-            base_path: "https://popgetter.blob.core.windows.net/popgetter-dagster-test/test_2"
-                .into(),
+            base_path:
+                "https://popgetter.blob.core.windows.net/popgetter-dagster-test/test_v2_release"
+                    .into(),
         }
     }
 }

--- a/src/display.rs
+++ b/src/display.rs
@@ -1,6 +1,6 @@
 use comfy_table::{presets::NOTHING, *};
 use itertools::izip;
-use popgetter::{COL, search::SearchResults};
+use popgetter::{search::SearchResults, COL};
 
 pub fn display_search_results(results: SearchResults, max_results: Option<usize>) {
     let df_to_show = match max_results {
@@ -10,7 +10,10 @@ pub fn display_search_results(results: SearchResults, max_results: Option<usize>
 
     for (metric_id, hrn, desc, hxl, level) in izip!(
         df_to_show.column(COL::METRIC_ID).unwrap().iter(),
-        df_to_show.column(COL::METRIC_HUMAN_READABLE_NAME).unwrap().iter(),
+        df_to_show
+            .column(COL::METRIC_HUMAN_READABLE_NAME)
+            .unwrap()
+            .iter(),
         df_to_show.column(COL::METRIC_DESCRIPTION).unwrap().iter(),
         df_to_show.column(COL::METRIC_HXL_TAG).unwrap().iter(),
         df_to_show.column(COL::GEOMETRY_LEVEL).unwrap().iter(),

--- a/src/display.rs
+++ b/src/display.rs
@@ -1,6 +1,6 @@
 use comfy_table::{presets::NOTHING, *};
 use itertools::izip;
-use popgetter::search::SearchResults;
+use popgetter::{COL, search::SearchResults};
 
 pub fn display_search_results(results: SearchResults, max_results: Option<usize>) {
     let df_to_show = match max_results {
@@ -9,11 +9,11 @@ pub fn display_search_results(results: SearchResults, max_results: Option<usize>
     };
 
     for (metric_id, hrn, desc, hxl, level) in izip!(
-        df_to_show.column("metric_id").unwrap().iter(),
-        df_to_show.column("human_readable_name").unwrap().iter(),
-        df_to_show.column("metric_description").unwrap().iter(),
-        df_to_show.column("metric_hxl_tag").unwrap().iter(),
-        df_to_show.column("geometry_level").unwrap().iter(),
+        df_to_show.column(COL::METRIC_ID).unwrap().iter(),
+        df_to_show.column(COL::METRIC_HUMAN_READABLE_NAME).unwrap().iter(),
+        df_to_show.column(COL::METRIC_DESCRIPTION).unwrap().iter(),
+        df_to_show.column(COL::METRIC_HXL_TAG).unwrap().iter(),
+        df_to_show.column(COL::GEOMETRY_LEVEL).unwrap().iter(),
     ) {
         let mut table = Table::new();
         table

--- a/src/geo.rs
+++ b/src/geo.rs
@@ -1,4 +1,4 @@
-use crate::{data_request_spec::BBox, GEO_ID_COL_NAME};
+use crate::{data_request_spec::BBox, COL};
 use anyhow::{Context, Result};
 use flatgeobuf::{geozero, FeatureProperties, HttpFgbReader};
 use geozero::ToWkt;
@@ -26,7 +26,7 @@ pub async fn get_geometries(
 
     let mut geoms: Vec<String> = vec![];
     let mut ids: Vec<String> = vec![];
-    let geoid_col = geoid_col.unwrap_or_else(|| GEO_ID_COL_NAME.to_owned());
+    let geoid_col = geoid_col.unwrap_or_else(|| COL::GEO_ID.to_owned());
 
     while let Some(feature) = fgb.next().await? {
         let props = feature.properties()?;
@@ -35,7 +35,7 @@ pub async fn get_geometries(
         ids.push(id.clone());
     }
 
-    let ids = Series::new(GEO_ID_COL_NAME, ids);
+    let ids = Series::new(COL::GEO_ID, ids);
     let geoms = Series::new("geometry", geoms);
     let result = DataFrame::new(vec![ids, geoms])?;
     Ok(result)
@@ -51,7 +51,7 @@ mod tests {
 
     fn test_fgb() -> FgbWriter<'static> {
         let mut fgb = FgbWriter::create("countries", GeometryType::Polygon).unwrap();
-        fgb.add_column(GEO_ID_COL_NAME, ColumnType::String, |_fbb, col| {
+        fgb.add_column(COL::GEO_ID, ColumnType::String, |_fbb, col| {
             col.nullable = false
         });
         let geom1 = GeoJson(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@ impl COL {
         "data_publisher_countries_of_interest";
 
     pub const GEOMETRY_ID: &'static str = "geometry_id";
-    pub const GEOMETRY_FILENAME_STEM: &'static str = "geometry_filename_stem";
+    pub const GEOMETRY_FILEPATH_STEM: &'static str = "geometry_filepath_stem";
     pub const GEOMETRY_VALIDITY_PERIOD_START: &'static str = "geometry_validity_period_start";
     pub const GEOMETRY_VALIDITY_PERIOD_END: &'static str = "geometry_validity_period_end";
     pub const GEOMETRY_LEVEL: &'static str = "geometry_level";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,11 +30,11 @@ impl COL {
     pub const COUNTRY_ISO2: &'static str = "country_iso2";
     pub const COUNTRY_ISO3166_2: &'static str = "country_iso3166_2";
 
-    pub const PUBLISHER_ID: &'static str = "data_publisher_id";
-    pub const PUBLISHER_NAME: &'static str = "data_publisher_name";
-    pub const PUBLISHER_URL: &'static str = "data_publisher_url";
-    pub const PUBLISHER_DESCRIPTION: &'static str = "data_publisher_description";
-    pub const PUBLISHER_COUNTRIES_OF_INTEREST: &'static str =
+    pub const DATA_PUBLISHER_ID: &'static str = "data_publisher_id";
+    pub const DATA_PUBLISHER_NAME: &'static str = "data_publisher_name";
+    pub const DATA_PUBLISHER_URL: &'static str = "data_publisher_url";
+    pub const DATA_PUBLISHER_DESCRIPTION: &'static str = "data_publisher_description";
+    pub const DATA_PUBLISHER_COUNTRIES_OF_INTEREST: &'static str =
         "data_publisher_countries_of_interest";
 
     pub const GEOMETRY_ID: &'static str = "geometry_id";
@@ -44,18 +44,26 @@ impl COL {
     pub const GEOMETRY_LEVEL: &'static str = "geometry_level";
     pub const GEOMETRY_HXL_TAG: &'static str = "geometry_hxl_tag";
 
-    pub const SOURCE_ID: &'static str = "source_id";
-    pub const SOURCE_NAME: &'static str = "source_name";
-    pub const SOURCE_DATE_PUBLISHED: &'static str = "source_date_published";
-    pub const SOURCE_REFERENCE_PERIOD_START: &'static str = "source_reference_period_start";
-    pub const SOURCE_REFERENCE_PERIOD_END: &'static str = "source_reference_period_end";
-    pub const SOURCE_COLLECTION_PERIOD_START: &'static str = "source_collection_period_start";
-    pub const SOURCE_COLLECTION_PERIOD_END: &'static str = "source_collection_period_end";
-    pub const SOURCE_EXPECT_NEXT_UPDATE: &'static str = "source_expect_next_update";
-    pub const SOURCE_URL: &'static str = "source_url";
-    pub const SOURCE_DATA_PUBLISHER_ID: &'static str = "source_data_publisher_id";
-    pub const SOURCE_DESCRIPTION: &'static str = "source_description";
-    pub const SOURCE_GEOMETRY_METADATA_ID: &'static str = "source_geometry_metadata_id";
+    pub const SOURCE_DATA_RELEASE_ID: &'static str = "source_data_release_id";
+    pub const SOURCE_DATA_RELEASE_NAME: &'static str = "source_data_release_name";
+    pub const SOURCE_DATA_RELEASE_DATE_PUBLISHED: &'static str =
+        "source_data_release_date_published";
+    pub const SOURCE_DATA_RELEASE_REFERENCE_PERIOD_START: &'static str =
+        "source_data_release_reference_period_start";
+    pub const SOURCE_DATA_RELEASE_REFERENCE_PERIOD_END: &'static str =
+        "source_data_release_reference_period_end";
+    pub const SOURCE_DATA_RELEASE_COLLECTION_PERIOD_START: &'static str =
+        "source_data_release_collection_period_start";
+    pub const SOURCE_DATA_RELEASE_COLLECTION_PERIOD_END: &'static str =
+        "source_data_release_collection_period_end";
+    pub const SOURCE_DATA_RELEASE_EXPECT_NEXT_UPDATE: &'static str =
+        "source_data_release_expect_next_update";
+    pub const SOURCE_DATA_RELEASE_URL: &'static str = "source_data_release_url";
+    pub const SOURCE_DATA_RELEASE_DATA_PUBLISHER_ID: &'static str =
+        "source_data_release_data_publisher_id";
+    pub const SOURCE_DATA_RELEASE_DESCRIPTION: &'static str = "source_data_release_description";
+    pub const SOURCE_DATA_RELEASE_GEOMETRY_METADATA_ID: &'static str =
+        "source_data_release_geometry_metadata_id";
 
     pub const METRIC_ID: &'static str = "metric_id";
     pub const METRIC_HUMAN_READABLE_NAME: &'static str = "metric_human_readable_name";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,7 +77,7 @@ impl COL {
     pub const METRIC_PARQUET_MARGIN_OF_ERROR_FILE: &'static str =
         "metric_parquet_margin_of_error_file";
     pub const METRIC_POTENTIAL_DENOMINATOR_IDS: &'static str = "metric_potential_denominator_ids";
-    pub const METRIC_PARENT_METRIC_ID: &'static str = "metric_parent_id";
+    pub const METRIC_PARENT_METRIC_ID: &'static str = "metric_parent_metric_id";
     pub const METRIC_SOURCE_DATA_RELEASE_ID: &'static str = "metric_source_data_release_id";
     pub const METRIC_SOURCE_DOWNLOAD_URL: &'static str = "metric_source_download_url";
     pub const METRIC_SOURCE_ARCHIVE_FILE_PATH: &'static str = "metric_source_archive_file_path";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,85 +7,21 @@ use polars::{frame::DataFrame, prelude::DataFrameJoinOps};
 use tokio::try_join;
 
 use crate::{config::Config, geo::get_geometries};
+
+// Re-exports
+pub use column_names as COL;
+
+// Modules
+pub mod column_names;
 pub mod config;
 pub mod data_request_spec;
 pub mod error;
+#[cfg(feature = "formatters")]
+pub mod formatters;
 pub mod geo;
 pub mod metadata;
 pub mod parquet;
 pub mod search;
-
-/// This struct stores the eventual column names of all the metadata classes, which are used when
-/// serialising the metadata to a dataframe. Note that this must be synchronised with column names
-/// defined in the upstream metadata classes!
-pub struct COL;
-
-impl COL {
-    pub const GEO_ID: &'static str = "GEO_ID";
-
-    pub const COUNTRY_ID: &'static str = "country_id";
-    pub const COUNTRY_NAME_SHORT_EN: &'static str = "country_name_short_en";
-    pub const COUNTRY_NAME_OFFICIAL: &'static str = "country_name_official";
-    pub const COUNTRY_ISO3: &'static str = "country_iso3";
-    pub const COUNTRY_ISO2: &'static str = "country_iso2";
-    pub const COUNTRY_ISO3166_2: &'static str = "country_iso3166_2";
-
-    pub const DATA_PUBLISHER_ID: &'static str = "data_publisher_id";
-    pub const DATA_PUBLISHER_NAME: &'static str = "data_publisher_name";
-    pub const DATA_PUBLISHER_URL: &'static str = "data_publisher_url";
-    pub const DATA_PUBLISHER_DESCRIPTION: &'static str = "data_publisher_description";
-    pub const DATA_PUBLISHER_COUNTRIES_OF_INTEREST: &'static str =
-        "data_publisher_countries_of_interest";
-
-    pub const GEOMETRY_ID: &'static str = "geometry_id";
-    pub const GEOMETRY_FILEPATH_STEM: &'static str = "geometry_filepath_stem";
-    pub const GEOMETRY_VALIDITY_PERIOD_START: &'static str = "geometry_validity_period_start";
-    pub const GEOMETRY_VALIDITY_PERIOD_END: &'static str = "geometry_validity_period_end";
-    pub const GEOMETRY_LEVEL: &'static str = "geometry_level";
-    pub const GEOMETRY_HXL_TAG: &'static str = "geometry_hxl_tag";
-
-    pub const SOURCE_DATA_RELEASE_ID: &'static str = "source_data_release_id";
-    pub const SOURCE_DATA_RELEASE_NAME: &'static str = "source_data_release_name";
-    pub const SOURCE_DATA_RELEASE_DATE_PUBLISHED: &'static str =
-        "source_data_release_date_published";
-    pub const SOURCE_DATA_RELEASE_REFERENCE_PERIOD_START: &'static str =
-        "source_data_release_reference_period_start";
-    pub const SOURCE_DATA_RELEASE_REFERENCE_PERIOD_END: &'static str =
-        "source_data_release_reference_period_end";
-    pub const SOURCE_DATA_RELEASE_COLLECTION_PERIOD_START: &'static str =
-        "source_data_release_collection_period_start";
-    pub const SOURCE_DATA_RELEASE_COLLECTION_PERIOD_END: &'static str =
-        "source_data_release_collection_period_end";
-    pub const SOURCE_DATA_RELEASE_EXPECT_NEXT_UPDATE: &'static str =
-        "source_data_release_expect_next_update";
-    pub const SOURCE_DATA_RELEASE_URL: &'static str = "source_data_release_url";
-    pub const SOURCE_DATA_RELEASE_DATA_PUBLISHER_ID: &'static str =
-        "source_data_release_data_publisher_id";
-    pub const SOURCE_DATA_RELEASE_DESCRIPTION: &'static str = "source_data_release_description";
-    pub const SOURCE_DATA_RELEASE_GEOMETRY_METADATA_ID: &'static str =
-        "source_data_release_geometry_metadata_id";
-
-    pub const METRIC_ID: &'static str = "metric_id";
-    pub const METRIC_HUMAN_READABLE_NAME: &'static str = "metric_human_readable_name";
-    pub const METRIC_SOURCE_METRIC_ID: &'static str = "metric_source_id";
-    pub const METRIC_DESCRIPTION: &'static str = "metric_description";
-    pub const METRIC_HXL_TAG: &'static str = "metric_hxl_tag";
-    pub const METRIC_PARQUET_PATH: &'static str = "metric_parquet_path";
-    pub const METRIC_PARQUET_COLUMN_NAME: &'static str = "metric_parquet_column_name";
-    pub const METRIC_PARQUET_MARGIN_OF_ERROR_COLUMN: &'static str =
-        "metric_parquet_margin_of_error_column";
-    pub const METRIC_PARQUET_MARGIN_OF_ERROR_FILE: &'static str =
-        "metric_parquet_margin_of_error_file";
-    pub const METRIC_POTENTIAL_DENOMINATOR_IDS: &'static str = "metric_potential_denominator_ids";
-    pub const METRIC_PARENT_METRIC_ID: &'static str = "metric_parent_metric_id";
-    pub const METRIC_SOURCE_DATA_RELEASE_ID: &'static str = "metric_source_data_release_id";
-    pub const METRIC_SOURCE_DOWNLOAD_URL: &'static str = "metric_source_download_url";
-    pub const METRIC_SOURCE_ARCHIVE_FILE_PATH: &'static str = "metric_source_archive_file_path";
-    pub const METRIC_SOURCE_DOCUMENTATION_URL: &'static str = "metric_source_documentation_url";
-}
-
-#[cfg(feature = "formatters")]
-pub mod formatters;
 
 pub struct Popgetter {
     pub metadata: Metadata,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@ pub mod metadata;
 pub mod parquet;
 pub mod search;
 
-/// This class stores the eventual column names of all the metadata classes, which are used when
+/// This struct stores the eventual column names of all the metadata classes, which are used when
 /// serialising the metadata to a dataframe. Note that this must be synchronised with column names
 /// defined in the upstream metadata classes!
 pub struct COL;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,66 @@ pub mod metadata;
 pub mod parquet;
 pub mod search;
 
-pub(crate) const GEO_ID_COL_NAME: &str = "GEO_ID";
+/// This class stores the eventual column names of all the metadata classes, which are used when
+/// serialising the metadata to a dataframe. Note that this must be synchronised with column names
+/// defined in the upstream metadata classes!
+pub struct COL;
+
+impl COL {
+    pub const GEO_ID: &'static str = "GEO_ID";
+
+    pub const COUNTRY_ID: &'static str = "country_id";
+    pub const COUNTRY_NAME_SHORT_EN: &'static str = "country_name_short_en";
+    pub const COUNTRY_NAME_OFFICIAL: &'static str = "country_name_official";
+    pub const COUNTRY_ISO3: &'static str = "country_iso3";
+    pub const COUNTRY_ISO2: &'static str = "country_iso2";
+    pub const COUNTRY_ISO3166_2: &'static str = "country_iso3166_2";
+
+    pub const PUBLISHER_ID: &'static str = "data_publisher_id";
+    pub const PUBLISHER_NAME: &'static str = "data_publisher_name";
+    pub const PUBLISHER_URL: &'static str = "data_publisher_url";
+    pub const PUBLISHER_DESCRIPTION: &'static str = "data_publisher_description";
+    pub const PUBLISHER_COUNTRIES_OF_INTEREST: &'static str =
+        "data_publisher_countries_of_interest";
+
+    pub const GEOMETRY_ID: &'static str = "geometry_id";
+    pub const GEOMETRY_FILENAME_STEM: &'static str = "geometry_filename_stem";
+    pub const GEOMETRY_VALIDITY_PERIOD_START: &'static str = "geometry_validity_period_start";
+    pub const GEOMETRY_VALIDITY_PERIOD_END: &'static str = "geometry_validity_period_end";
+    pub const GEOMETRY_LEVEL: &'static str = "geometry_level";
+    pub const GEOMETRY_HXL_TAG: &'static str = "geometry_hxl_tag";
+
+    pub const SOURCE_ID: &'static str = "source_id";
+    pub const SOURCE_NAME: &'static str = "source_name";
+    pub const SOURCE_DATE_PUBLISHED: &'static str = "source_date_published";
+    pub const SOURCE_REFERENCE_PERIOD_START: &'static str = "source_reference_period_start";
+    pub const SOURCE_REFERENCE_PERIOD_END: &'static str = "source_reference_period_end";
+    pub const SOURCE_COLLECTION_PERIOD_START: &'static str = "source_collection_period_start";
+    pub const SOURCE_COLLECTION_PERIOD_END: &'static str = "source_collection_period_end";
+    pub const SOURCE_EXPECT_NEXT_UPDATE: &'static str = "source_expect_next_update";
+    pub const SOURCE_URL: &'static str = "source_url";
+    pub const SOURCE_DATA_PUBLISHER_ID: &'static str = "source_data_publisher_id";
+    pub const SOURCE_DESCRIPTION: &'static str = "source_description";
+    pub const SOURCE_GEOMETRY_METADATA_ID: &'static str = "source_geometry_metadata_id";
+
+    pub const METRIC_ID: &'static str = "metric_id";
+    pub const METRIC_HUMAN_READABLE_NAME: &'static str = "metric_human_readable_name";
+    pub const METRIC_SOURCE_METRIC_ID: &'static str = "metric_source_id";
+    pub const METRIC_DESCRIPTION: &'static str = "metric_description";
+    pub const METRIC_HXL_TAG: &'static str = "metric_hxl_tag";
+    pub const METRIC_PARQUET_PATH: &'static str = "metric_parquet_path";
+    pub const METRIC_PARQUET_COLUMN_NAME: &'static str = "metric_parquet_column_name";
+    pub const METRIC_PARQUET_MARGIN_OF_ERROR_COLUMN: &'static str =
+        "metric_parquet_margin_of_error_column";
+    pub const METRIC_PARQUET_MARGIN_OF_ERROR_FILE: &'static str =
+        "metric_parquet_margin_of_error_file";
+    pub const METRIC_POTENTIAL_DENOMINATOR_IDS: &'static str = "metric_potential_denominator_ids";
+    pub const METRIC_PARENT_METRIC_ID: &'static str = "metric_parent_id";
+    pub const METRIC_SOURCE_DATA_RELEASE_ID: &'static str = "metric_source_data_release_id";
+    pub const METRIC_SOURCE_DOWNLOAD_URL: &'static str = "metric_source_download_url";
+    pub const METRIC_SOURCE_ARCHIVE_FILE_PATH: &'static str = "metric_source_archive_file_path";
+    pub const METRIC_SOURCE_DOCUMENTATION_URL: &'static str = "metric_source_documentation_url";
+}
 
 #[cfg(feature = "formatters")]
 pub mod formatters;
@@ -61,7 +120,7 @@ impl Popgetter {
         debug!("geoms: {geoms:#?}");
         debug!("metrics: {metrics:#?}");
 
-        let result = geoms.inner_join(&metrics?, [GEO_ID_COL_NAME], ["GEO_ID"])?;
+        let result = geoms.inner_join(&metrics?, [COL::GEO_ID], [COL::GEO_ID])?;
         Ok(result)
     }
 }

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -17,7 +17,7 @@ use polars::{
 };
 use serde::{Deserialize, Serialize};
 
-use crate::{config::Config, data_request_spec::GeometrySpec, parquet::MetricRequest};
+use crate::{config::Config, data_request_spec::GeometrySpec, parquet::MetricRequest, COL};
 
 /// This struct contains the base url and names of
 /// the files that contain the metadata. It has a
@@ -49,9 +49,9 @@ impl MetricId {
     /// Returns the column in the metadata that this id type corrispondes to
     pub fn to_col_name(&self) -> String {
         match self {
-            MetricId::Hxl(_) => "metric_hxl_tag".into(),
-            MetricId::Id(_) => "metric_id".into(),
-            MetricId::CommonName(_) => "human_readable_name".into(),
+            MetricId::Hxl(_) => COL::METRIC_HXL_TAG.into(),
+            MetricId::Id(_) => COL::METRIC_ID.into(),
+            MetricId::CommonName(_) => COL::METRIC_HUMAN_READABLE_NAME.into(),
         }
     }
     /// Return a string representing the textual content of the ID
@@ -114,7 +114,7 @@ impl ExpandedMetadataTable {
 
     /// Filter the dataframe by the specified metrics
     pub fn select_metrics(&self, metrics: &[MetricId]) -> Self {
-        debug!("{:#?}", metrics);
+        debug!("metrics = {:#?}", metrics);
         let mut id_collections: HashMap<String, Vec<String>> = HashMap::new();
 
         for metric in metrics {
@@ -125,17 +125,17 @@ impl ExpandedMetadataTable {
         }
 
         let mut filter_expression: Option<Expr> = None;
-        debug!("{:#?}", id_collections);
+        debug!("id_collections = {:#?}", id_collections);
         for (col_name, ids) in &id_collections {
             let filter_series = Series::new("filter", ids.clone());
-            debug!("{:#?}", filter_series);
+            debug!("filter_series = {:#?}", filter_series);
             filter_expression = if let Some(expression) = filter_expression {
                 Some(expression.or(col(col_name).is_in(lit(filter_series))))
             } else {
                 Some(col(col_name).is_in(lit(filter_series)))
             };
         }
-        debug!("{:#?}", filter_expression);
+        debug!("filter_expression = {:#?}", filter_expression);
         ExpandedMetadataTable(self.as_df().filter(filter_expression.unwrap()))
     }
 
@@ -143,14 +143,17 @@ impl ExpandedMetadataTable {
     pub fn to_metric_requests(&self, config: &Config) -> Result<Vec<MetricRequest>> {
         let df = self
             .as_df()
-            .select([col("metric_parquet_path"), col("parquet_column_name")])
+            .select([
+                col(COL::METRIC_PARQUET_PATH),
+                col(COL::METRIC_PARQUET_COLUMN_NAME),
+            ])
             .collect()?;
         debug!("{}", df);
         let metric_requests: Vec<MetricRequest> = df
-            .column("parquet_column_name")?
+            .column(COL::METRIC_PARQUET_COLUMN_NAME)?
             .str()?
             .into_iter()
-            .zip(df.column("metric_parquet_path")?.str()?)
+            .zip(df.column(COL::METRIC_PARQUET_PATH)?.str()?)
             .filter_map(|(column, file)| {
                 if let (Some(column), Some(file)) = (column, file) {
                     Some(MetricRequest {
@@ -167,7 +170,10 @@ impl ExpandedMetadataTable {
 
     /// Select a specific geometry level in the dataframe filtering out all others
     pub fn select_geometry(&self, geometry: &str) -> Self {
-        ExpandedMetadataTable(self.as_df().filter(col("geometry_level").eq(lit(geometry))))
+        ExpandedMetadataTable(
+            self.as_df()
+                .filter(col(COL::GEOMETRY_LEVEL).eq(lit(geometry))),
+        )
     }
 
     /// Select a specific set of years in the dataframe filtering out all others
@@ -186,8 +192,8 @@ impl ExpandedMetadataTable {
     pub fn avaliable_geometries(&self) -> Result<Vec<String>> {
         let df = self.as_df();
         let counts: DataFrame = df
-            .group_by([col("geometry_level")])
-            .agg([col("geometry_level").count().alias("count")])
+            .group_by([col(COL::GEOMETRY_LEVEL)])
+            .agg([col(COL::GEOMETRY_LEVEL).count().alias("count")])
             .sort(
                 ["count"],
                 SortMultipleOptions::new().with_order_descending(true),
@@ -195,7 +201,7 @@ impl ExpandedMetadataTable {
             .collect()?;
 
         Ok(counts
-            .column("geometry_level")?
+            .column(COL::GEOMETRY_LEVEL)?
             .str()?
             .iter()
             .filter_map(|geom| geom.map(std::borrow::ToOwned::to_owned))
@@ -225,9 +231,9 @@ impl ExpandedMetadataTable {
     /// Get fully speced metric ids
     pub fn get_explicit_metric_ids(&self) -> Result<Vec<MetricId>> {
         debug!("{}", self.as_df().collect()?);
-        let reamining: DataFrame = self.as_df().select([col("metric_id")]).collect()?;
+        let reamining: DataFrame = self.as_df().select([col(COL::METRIC_ID)]).collect()?;
         Ok(reamining
-            .column("metric_id")?
+            .column(COL::METRIC_ID)?
             .str()?
             .into_iter()
             .filter_map(|pos_id| pos_id.map(|id| MetricId::Id(id.to_owned())))
@@ -305,86 +311,27 @@ impl Metadata {
             .metrics
             .clone()
             .lazy()
-            // Rename these first because they will cause clashes when merging
-            .rename(
-                ["id", "description", "hxl_tag"],
-                ["metric_id", "metric_description", "metric_hxl_tag"],
-            )
             // Join source data releases
             .join(
                 self.source_data_releases.clone().lazy(),
-                [col("source_data_release_id")],
-                [col("id")],
+                [col(COL::METRIC_SOURCE_DATA_RELEASE_ID)],
+                [col(COL::SOURCE_ID)],
                 JoinArgs::new(JoinType::Inner),
-            )
-            .rename(
-                [
-                    "url",
-                    "description",
-                    "name",
-                    "date_published",
-                    "reference_period_start",
-                    "reference_period_end",
-                    "collection_period_start",
-                    "collection_period_end",
-                    "expect_next_update",
-                ],
-                [
-                    "release_url",
-                    "release_description",
-                    "release_name",
-                    "release_date_published",
-                    "release_reference_period_start",
-                    "release_reference_period_end",
-                    "release_collection_period_start",
-                    "release_collection_period_end",
-                    "release_expect_next_update",
-                ],
             )
             // Join geometry metadata
             .join(
                 self.geometries.clone().lazy(),
-                [col("geometry_metadata_id")],
-                [col("id")],
+                [col(COL::SOURCE_GEOMETRY_METADATA_ID)],
+                [col(COL::GEOMETRY_ID)],
                 JoinArgs::new(JoinType::Inner),
-            )
-            .rename(
-                [
-                    "validity_period_start",
-                    "validity_period_end",
-                    "level",
-                    "hxl_tag",
-                    "filename_stem",
-                ],
-                [
-                    "geometry_validity_period_start",
-                    "geometry_validity_period_end",
-                    "geometry_level",
-                    "geometry_hxl_tag",
-                    "geometry_filename_stem",
-                ],
             )
             // Join data publishers
             .join(
                 self.data_publishers.clone().lazy(),
-                [col("data_publisher_id")],
-                [col("id")],
+                [col(COL::SOURCE_DATA_PUBLISHER_ID)],
+                [col(COL::PUBLISHER_ID)],
                 JoinArgs::new(JoinType::Inner),
-            )
-            .rename(
-                ["url", "description", "name"],
-                [
-                    "data_publisher_url",
-                    "data_publisher_description",
-                    "data_publisher_name",
-                ],
-            )
-            // Get rid of intermediate IDs as we don't need them
-            .drop([
-                "source_data_release_id",
-                "geometry_metadata_id",
-                "data_publisher_id",
-            ]);
+            );
         // TODO: Add a country_id column to the metadata, and merge in the countries as well. See
         // https://github.com/Urban-Analytics-Technology-Platform/popgetter/issues/104
 

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -615,9 +615,8 @@ mod tests {
             .load(&config)
             .await
             .unwrap();
-        let expanded_metrics = metadata.expand_regex_metric(
-            &MetricId::Hxl(r"population\+adm5".into())
-        );
+        let expanded_metrics =
+            metadata.expand_regex_metric(&MetricId::Hxl(r"population\+adm5".into()));
         assert!(
             expanded_metrics.is_ok(),
             "Should successfully expand metrics"
@@ -637,9 +636,7 @@ mod tests {
 
         assert_eq!(
             metric_names,
-            vec![
-                "#population+adm5+total+2023",
-            ],
+            vec!["#population+adm5+total+2023",],
             "should get the correct metrics"
         );
     }

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -315,21 +315,21 @@ impl Metadata {
             .join(
                 self.source_data_releases.clone().lazy(),
                 [col(COL::METRIC_SOURCE_DATA_RELEASE_ID)],
-                [col(COL::SOURCE_ID)],
+                [col(COL::SOURCE_DATA_RELEASE_ID)],
                 JoinArgs::new(JoinType::Inner),
             )
             // Join geometry metadata
             .join(
                 self.geometries.clone().lazy(),
-                [col(COL::SOURCE_GEOMETRY_METADATA_ID)],
+                [col(COL::SOURCE_DATA_RELEASE_GEOMETRY_METADATA_ID)],
                 [col(COL::GEOMETRY_ID)],
                 JoinArgs::new(JoinType::Inner),
             )
             // Join data publishers
             .join(
                 self.data_publishers.clone().lazy(),
-                [col(COL::SOURCE_DATA_PUBLISHER_ID)],
-                [col(COL::PUBLISHER_ID)],
+                [col(COL::SOURCE_DATA_RELEASE_DATA_PUBLISHER_ID)],
+                [col(COL::DATA_PUBLISHER_ID)],
                 JoinArgs::new(JoinType::Inner),
             );
         // TODO: Add a country_id column to the metadata, and merge in the countries as well. See

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -595,7 +595,7 @@ mod tests {
     #[tokio::test]
     async fn country_metadata_should_load() {
         let config = Config::default();
-        let metadata = CountryMetadataLoader::new("be").load(&config).await;
+        let metadata = CountryMetadataLoader::new("bel").load(&config).await;
         println!("{metadata:#?}");
         assert!(metadata.is_ok(), "Data should have loaded ok");
     }
@@ -611,89 +611,13 @@ mod tests {
     #[tokio::test]
     async fn metric_ids_should_expand_properly() {
         let config = Config::default();
-        let metadata = CountryMetadataLoader::new("be")
+        let metadata = CountryMetadataLoader::new("bel")
             .load(&config)
             .await
             .unwrap();
-        let expanded_metrics = metadata.expand_regex_metric(&MetricId::Hxl("population-*".into()));
-        assert!(
-            expanded_metrics.is_ok(),
-            "Should successfully expand metrics"
+        let expanded_metrics = metadata.expand_regex_metric(
+            &MetricId::Hxl(r"population\+adm5".into())
         );
-        let expanded_metrics = expanded_metrics.unwrap();
-
-        assert_eq!(
-            expanded_metrics.len(),
-            7,
-            "should return the correct number of metrics"
-        );
-
-        let metric_names: Vec<&str> = expanded_metrics
-            .iter()
-            .map(MetricId::to_query_string)
-            .collect();
-
-        assert_eq!(
-            metric_names,
-            vec![
-                "#population+children+age5_17",
-                "#population+infants+age0_4",
-                "#population+children+age0_17",
-                "#population+adults+f",
-                "#population+adults+m",
-                "#population+adults",
-                "#population+ind"
-            ],
-            "should get the correct metrics"
-        );
-    }
-
-    #[tokio::test]
-    async fn human_readable_metric_ids_should_expand_properly() {
-        let config = Config::default();
-        let metadata = CountryMetadataLoader::new("be")
-            .load(&config)
-            .await
-            .unwrap();
-        let expanded_metrics =
-            metadata.expand_regex_metric(&MetricId::CommonName("Children*".into()));
-
-        println!("{:#?}", expanded_metrics);
-
-        assert!(
-            expanded_metrics.is_ok(),
-            "Should successfully expand metrics"
-        );
-
-        let expanded_metrics = expanded_metrics.unwrap();
-
-        assert_eq!(
-            expanded_metrics.len(),
-            2,
-            "should return the correct number of metrics"
-        );
-
-        let metric_names: Vec<&str> = expanded_metrics
-            .iter()
-            .map(MetricId::to_query_string)
-            .collect();
-
-        assert_eq!(
-            metric_names,
-            vec!["Children aged 5 to 17", "Children aged 0 to 17"],
-            "should get the correct metrics"
-        );
-    }
-
-    #[tokio::test]
-    async fn fully_defined_metric_ids_should_expand_to_itself() {
-        let config = Config::default();
-        let metadata = CountryMetadataLoader::new("be")
-            .load(&config)
-            .await
-            .unwrap();
-        let expanded_metrics =
-            metadata.expand_regex_metric(&MetricId::Hxl(r"#population\+infants\+age0\_4".into()));
         assert!(
             expanded_metrics.is_ok(),
             "Should successfully expand metrics"
@@ -713,7 +637,79 @@ mod tests {
 
         assert_eq!(
             metric_names,
-            vec!["#population+infants+age0_4",],
+            vec![
+                "#population+adm5+total+2023",
+            ],
+            "should get the correct metrics"
+        );
+    }
+
+    #[tokio::test]
+    async fn human_readable_metric_ids_should_expand_properly() {
+        let config = Config::default();
+        let metadata = CountryMetadataLoader::new("bel")
+            .load(&config)
+            .await
+            .unwrap();
+        let expanded_metrics =
+            metadata.expand_regex_metric(&MetricId::CommonName("Population, total".into()));
+
+        println!("{:#?}", expanded_metrics);
+
+        assert!(
+            expanded_metrics.is_ok(),
+            "Should successfully expand metrics"
+        );
+
+        let expanded_metrics = expanded_metrics.unwrap();
+
+        assert_eq!(
+            expanded_metrics.len(),
+            1,
+            "should return the correct number of metrics"
+        );
+
+        let metric_names: Vec<&str> = expanded_metrics
+            .iter()
+            .map(MetricId::to_query_string)
+            .collect();
+
+        assert_eq!(
+            metric_names,
+            vec!["Population, total, 2023"],
+            "should get the correct metrics"
+        );
+    }
+
+    #[tokio::test]
+    async fn fully_defined_metric_ids_should_expand_to_itself() {
+        let config = Config::default();
+        let metadata = CountryMetadataLoader::new("bel")
+            .load(&config)
+            .await
+            .unwrap();
+        let expanded_metrics =
+            metadata.expand_regex_metric(&MetricId::Hxl(r"#population\+adm5\+total\+2023".into()));
+        assert!(
+            expanded_metrics.is_ok(),
+            "Should successfully expand metrics"
+        );
+        let expanded_metrics = expanded_metrics.unwrap();
+
+        assert_eq!(
+            expanded_metrics.len(),
+            1,
+            "should return the correct number of metrics"
+        );
+
+        let metric_names: Vec<&str> = expanded_metrics
+            .iter()
+            .map(MetricId::to_query_string)
+            .collect();
+
+        assert_eq!(
+            metric_names,
+            vec!["#population+adm5+total+2023"],
             "should get the correct metrics"
         );
 

--- a/src/parquet.rs
+++ b/src/parquet.rs
@@ -3,7 +3,7 @@ use log::debug;
 use polars::prelude::*;
 use std::collections::HashSet;
 
-use crate::GEO_ID_COL_NAME;
+use crate::COL;
 
 #[derive(Debug)]
 pub struct MetricRequest {
@@ -19,7 +19,7 @@ fn get_metrics_from_file(
     geo_ids: Option<&[&str]>,
 ) -> Result<DataFrame> {
     let mut cols: Vec<Expr> = columns.iter().map(|c| col(c)).collect();
-    cols.push(col(GEO_ID_COL_NAME));
+    cols.push(col(COL::GEO_ID));
 
     let args = ScanArgsParquet::default();
 
@@ -29,7 +29,7 @@ fn get_metrics_from_file(
 
     let df = if let Some(ids) = geo_ids {
         let id_series = Series::new("geo_ids", ids);
-        df.filter(col(GEO_ID_COL_NAME).is_in(lit(id_series)))
+        df.filter(col(COL::GEO_ID).is_in(lit(id_series)))
     } else {
         df
     };
@@ -71,8 +71,8 @@ pub fn get_metrics(metrics: &[MetricRequest], geo_ids: Option<&[&str]>) -> Resul
         if let Some(prev_dfs) = joined_df {
             joined_df = Some(prev_dfs.join(
                 &df,
-                vec![GEO_ID_COL_NAME],
-                vec![GEO_ID_COL_NAME],
+                vec![COL::GEO_ID],
+                vec![COL::GEO_ID],
                 JoinArgs::new(JoinType::Inner),
             )?);
         } else {
@@ -108,7 +108,7 @@ mod tests {
             "The returned dataframe should have the correct number of rows"
         );
         assert!(
-            df.column(GEO_ID_COL_NAME).is_ok(),
+            df.column(COL::GEO_ID).is_ok(),
             "The returned dataframe should have a GEO_ID column"
         );
         assert!(

--- a/src/search.rs
+++ b/src/search.rs
@@ -1,6 +1,6 @@
 //! Search
 
-use crate::metadata::Metadata;
+use crate::{metadata::Metadata, COL};
 use chrono::NaiveDate;
 use log::debug;
 use polars::lazy::dsl::{col, lit, Expr};
@@ -60,12 +60,12 @@ impl From<SearchText> for Option<Expr> {
             .context
             .iter()
             .map(|field| match field {
-                SearchContext::Hxl => case_insensitive_contains("metric_hxl_tag", &val.text),
+                SearchContext::Hxl => case_insensitive_contains(COL::METRIC_HXL_TAG, &val.text),
                 SearchContext::HumanReadableName => {
-                    case_insensitive_contains("human_readable_name", &val.text)
+                    case_insensitive_contains(COL::METRIC_HUMAN_READABLE_NAME, &val.text)
                 }
                 SearchContext::Description => {
-                    case_insensitive_contains("metric_description", &val.text)
+                    case_insensitive_contains(COL::METRIC_DESCRIPTION, &val.text)
                 }
             })
             .collect();
@@ -76,13 +76,13 @@ impl From<SearchText> for Option<Expr> {
 impl From<YearRange> for Expr {
     fn from(value: YearRange) -> Self {
         match value {
-            YearRange::Before(year) => col("release_reference_period_start")
+            YearRange::Before(year) => col(COL::SOURCE_REFERENCE_PERIOD_START)
                 .lt_eq(lit(NaiveDate::from_ymd_opt(year.into(), 12, 31).unwrap())),
-            YearRange::After(year) => col("release_reference_period_end")
+            YearRange::After(year) => col(COL::SOURCE_REFERENCE_PERIOD_END)
                 .gt_eq(lit(NaiveDate::from_ymd_opt(year.into(), 1, 1).unwrap())),
             YearRange::Between(start, end) => {
-                let start_col = col("release_reference_period_start");
-                let end_col = col("release_reference_period_end");
+                let start_col = col(COL::SOURCE_REFERENCE_PERIOD_START);
+                let end_col = col(COL::SOURCE_REFERENCE_PERIOD_END);
                 let start_date = lit(NaiveDate::from_ymd_opt(start.into(), 1, 1).unwrap());
                 let end_date = lit(NaiveDate::from_ymd_opt(end.into(), 12, 31).unwrap());
                 // (start_col <= start_date AND end_col >= start_date)
@@ -109,7 +109,7 @@ impl From<DataPublisher> for Option<Expr> {
             value
                 .0
                 .iter()
-                .map(|val| case_insensitive_contains("data_publisher_name", val))
+                .map(|val| case_insensitive_contains(COL::PUBLISHER_NAME, val))
                 .collect(),
         )
     }
@@ -121,7 +121,7 @@ impl From<SourceDataRelease> for Option<Expr> {
             value
                 .0
                 .iter()
-                .map(|val| case_insensitive_contains("source_data_release_id", val))
+                .map(|val| case_insensitive_contains(COL::SOURCE_NAME, val))
                 .collect(),
         )
     }
@@ -133,7 +133,7 @@ impl From<GeometryLevel> for Option<Expr> {
             value
                 .0
                 .iter()
-                .map(|val| case_insensitive_contains("geometry_level", val))
+                .map(|val| case_insensitive_contains(COL::GEOMETRY_LEVEL, val))
                 .collect(),
         )
     }
@@ -145,7 +145,7 @@ impl From<Country> for Option<Expr> {
             value
                 .0
                 .iter()
-                .map(|val| case_insensitive_contains("country_name", val))
+                .map(|val| case_insensitive_contains(COL::COUNTRY_NAME_SHORT_EN, val))
                 .collect(),
         )
     }
@@ -157,7 +157,7 @@ impl From<SourceMetricId> for Option<Expr> {
             value
                 .0
                 .iter()
-                .map(|val| case_insensitive_contains("source_metric_id", val))
+                .map(|val| case_insensitive_contains(COL::METRIC_SOURCE_METRIC_ID, val))
                 .collect(),
         )
     }

--- a/src/search.rs
+++ b/src/search.rs
@@ -76,13 +76,13 @@ impl From<SearchText> for Option<Expr> {
 impl From<YearRange> for Expr {
     fn from(value: YearRange) -> Self {
         match value {
-            YearRange::Before(year) => col(COL::SOURCE_REFERENCE_PERIOD_START)
+            YearRange::Before(year) => col(COL::SOURCE_DATA_RELEASE_REFERENCE_PERIOD_START)
                 .lt_eq(lit(NaiveDate::from_ymd_opt(year.into(), 12, 31).unwrap())),
-            YearRange::After(year) => col(COL::SOURCE_REFERENCE_PERIOD_END)
+            YearRange::After(year) => col(COL::SOURCE_DATA_RELEASE_REFERENCE_PERIOD_END)
                 .gt_eq(lit(NaiveDate::from_ymd_opt(year.into(), 1, 1).unwrap())),
             YearRange::Between(start, end) => {
-                let start_col = col(COL::SOURCE_REFERENCE_PERIOD_START);
-                let end_col = col(COL::SOURCE_REFERENCE_PERIOD_END);
+                let start_col = col(COL::SOURCE_DATA_RELEASE_REFERENCE_PERIOD_START);
+                let end_col = col(COL::SOURCE_DATA_RELEASE_REFERENCE_PERIOD_END);
                 let start_date = lit(NaiveDate::from_ymd_opt(start.into(), 1, 1).unwrap());
                 let end_date = lit(NaiveDate::from_ymd_opt(end.into(), 12, 31).unwrap());
                 // (start_col <= start_date AND end_col >= start_date)
@@ -109,7 +109,7 @@ impl From<DataPublisher> for Option<Expr> {
             value
                 .0
                 .iter()
-                .map(|val| case_insensitive_contains(COL::PUBLISHER_NAME, val))
+                .map(|val| case_insensitive_contains(COL::DATA_PUBLISHER_NAME, val))
                 .collect(),
         )
     }
@@ -121,7 +121,7 @@ impl From<SourceDataRelease> for Option<Expr> {
             value
                 .0
                 .iter()
-                .map(|val| case_insensitive_contains(COL::SOURCE_NAME, val))
+                .map(|val| case_insensitive_contains(COL::SOURCE_DATA_RELEASE_NAME, val))
                 .collect(),
         )
     }


### PR DESCRIPTION
Companion PR to https://github.com/Urban-Analytics-Technology-Platform/popgetter/pull/130.

Merge that first and regenerate all the BE/NI data before testing this PR! The CI is failing now because the proposed changes do not match our current data.

This PR:

 - Reworks the function which joins all metadata tables to use the new column names.
 - Defines all the column names in a single struct impl, and gets rid of all the remaining magic constants.

It would be cool if we had a test to get the column names from upstream Python and check that they are equal to the ones here. I haven't done that, though. Alternatively, if we one day merge the two repos into one, they could potentially be derived from the same file.