### PR TITLE
Country search and rename binary as popgetter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,10 @@ edition = "2021"
 name = "popgetter"
 path = "src/lib.rs"
 
+[[bin]]
+name = "popgetter"
+path = "src/main.rs"
+
 [dependencies]
 anyhow = "1.0.75"
 serde = { version = "1.0", features = ["derive"] }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -266,13 +266,13 @@ impl RunCommand for MetricsCommand {
         println!("Found {} metrics.", len_requests);
 
         if len_requests > 50 && !self.full {
-            display_search_results(search_results, Some(50));
+            display_search_results(search_results, Some(50))?;
             println!(
                 "{} more results not shown. Use --full to show all results.",
                 len_requests - 50
             );
         } else {
-            display_search_results(search_results, None);
+            display_search_results(search_results, None)?;
         }
         Ok(())
     }

--- a/src/display.rs
+++ b/src/display.rs
@@ -12,7 +12,7 @@ pub fn display_search_results(
         None => results.0,
     };
 
-    for (metric_id, hrn, desc, hxl, date, country, level) in izip!(
+    for (metric_id, hrn, desc, hxl, date, country, level, download_url) in izip!(
         df_to_show.column(COL::METRIC_ID)?.str()?,
         df_to_show.column(COL::METRIC_HUMAN_READABLE_NAME)?.str()?,
         df_to_show.column(COL::METRIC_DESCRIPTION)?.str()?,
@@ -23,7 +23,11 @@ pub fn display_search_results(
             .iter(),
         df_to_show.column(COL::COUNTRY_NAME_SHORT_EN)?.str()?,
         // Note: if using iter on an AnyValue, need to rechunk first.
-        df_to_show.column(COL::GEOMETRY_LEVEL)?.rechunk().iter()
+        df_to_show.column(COL::GEOMETRY_LEVEL)?.rechunk().iter(),
+        df_to_show
+            .column(COL::METRIC_SOURCE_DOWNLOAD_URL)?
+            .rechunk()
+            .iter()
     ) {
         let mut table = Table::new();
         table
@@ -36,6 +40,15 @@ pub fn display_search_results(
             .add_row(vec![
                 Cell::new("Metric ID").add_attribute(Attribute::Bold),
                 metric_id.unwrap().into(),
+            ])
+            .add_row(vec![
+                Cell::new("Metric ID (short)").add_attribute(Attribute::Bold),
+                metric_id
+                    .unwrap()
+                    .chars()
+                    .take(8)
+                    .collect::<String>()
+                    .into(),
             ])
             .add_row(vec![
                 Cell::new("Human readable name").add_attribute(Attribute::Bold),
@@ -60,6 +73,10 @@ pub fn display_search_results(
             .add_row(vec![
                 Cell::new("Geometry level").add_attribute(Attribute::Bold),
                 level.get_str().unwrap().into(),
+            ])
+            .add_row(vec![
+                Cell::new("Source download URL").add_attribute(Attribute::Bold),
+                download_url.get_str().unwrap().into(),
             ]);
 
         let column = table.column_mut(0).unwrap();

--- a/src/display.rs
+++ b/src/display.rs
@@ -3,32 +3,29 @@ use itertools::izip;
 use log::debug;
 use popgetter::{search::SearchResults, COL};
 
-pub fn display_search_results(results: SearchResults, max_results: Option<usize>) {
+pub fn display_search_results(
+    results: SearchResults,
+    max_results: Option<usize>,
+) -> anyhow::Result<()> {
     let df_to_show = match max_results {
         Some(max) => results.0.head(Some(max)),
         None => results.0,
     };
 
     for (metric_id, hrn, desc, hxl, date, country, level) in izip!(
-        df_to_show.column(COL::METRIC_ID).unwrap().iter(),
+        df_to_show.column(COL::METRIC_ID)?.str()?,
+        df_to_show.column(COL::METRIC_HUMAN_READABLE_NAME)?.str()?,
+        df_to_show.column(COL::METRIC_DESCRIPTION)?.str()?,
+        df_to_show.column(COL::METRIC_HXL_TAG)?.str()?,
         df_to_show
-            .column(COL::METRIC_HUMAN_READABLE_NAME)
-            .unwrap()
+            .column(COL::SOURCE_DATA_RELEASE_COLLECTION_PERIOD_START)?
+            .rechunk()
             .iter(),
-        df_to_show.column(COL::METRIC_DESCRIPTION).unwrap().iter(),
-        df_to_show.column(COL::METRIC_HXL_TAG).unwrap().iter(),
-        df_to_show
-            .column(COL::SOURCE_DATA_RELEASE_COLLECTION_PERIOD_START)
-            .unwrap()
-            .iter(),
-        df_to_show
-            .column(COL::COUNTRY_NAME_SHORT_EN)
-            .unwrap()
-            .iter(),
-        df_to_show.column(COL::GEOMETRY_LEVEL).unwrap().iter(),
+        df_to_show.column(COL::COUNTRY_NAME_SHORT_EN)?.str()?,
+        // Note: if using iter on an AnyValue, need to rechunk first.
+        df_to_show.column(COL::GEOMETRY_LEVEL)?.rechunk().iter()
     ) {
         let mut table = Table::new();
-        debug!("{:#?}", country);
         table
             .load_preset(NOTHING)
             .set_content_arrangement(ContentArrangement::Dynamic)
@@ -38,19 +35,19 @@ pub fn display_search_results(results: SearchResults, max_results: Option<usize>
             .set_style(comfy_table::TableComponent::TopBorderIntersections, '─')
             .add_row(vec![
                 Cell::new("Metric ID").add_attribute(Attribute::Bold),
-                metric_id.get_str().unwrap().into(),
+                metric_id.unwrap().into(),
             ])
             .add_row(vec![
                 Cell::new("Human readable name").add_attribute(Attribute::Bold),
-                hrn.get_str().unwrap().into(),
+                hrn.unwrap().into(),
             ])
             .add_row(vec![
                 Cell::new("Description").add_attribute(Attribute::Bold),
-                desc.get_str().unwrap().into(),
+                desc.unwrap().into(),
             ])
             .add_row(vec![
                 Cell::new("HXL tag").add_attribute(Attribute::Bold),
-                hxl.get_str().unwrap().into(),
+                hxl.unwrap().into(),
             ])
             .add_row(vec![
                 Cell::new("Collection date").add_attribute(Attribute::Bold),
@@ -58,7 +55,7 @@ pub fn display_search_results(results: SearchResults, max_results: Option<usize>
             ])
             .add_row(vec![
                 Cell::new("Country").add_attribute(Attribute::Bold),
-                country.get_str().unwrap().into(),
+                country.unwrap().into(),
             ])
             .add_row(vec![
                 Cell::new("Geometry level").add_attribute(Attribute::Bold),
@@ -70,4 +67,5 @@ pub fn display_search_results(results: SearchResults, max_results: Option<usize>
 
         println!("\n{}", table);
     }
+    Ok(())
 }

--- a/src/display.rs
+++ b/src/display.rs
@@ -1,5 +1,6 @@
 use comfy_table::{presets::NOTHING, *};
 use itertools::izip;
+use log::debug;
 use popgetter::{search::SearchResults, COL};
 
 pub fn display_search_results(results: SearchResults, max_results: Option<usize>) {
@@ -8,7 +9,7 @@ pub fn display_search_results(results: SearchResults, max_results: Option<usize>
         None => results.0,
     };
 
-    for (metric_id, hrn, desc, hxl, level) in izip!(
+    for (metric_id, hrn, desc, hxl, date, country, level) in izip!(
         df_to_show.column(COL::METRIC_ID).unwrap().iter(),
         df_to_show
             .column(COL::METRIC_HUMAN_READABLE_NAME)
@@ -16,9 +17,18 @@ pub fn display_search_results(results: SearchResults, max_results: Option<usize>
             .iter(),
         df_to_show.column(COL::METRIC_DESCRIPTION).unwrap().iter(),
         df_to_show.column(COL::METRIC_HXL_TAG).unwrap().iter(),
+        df_to_show
+            .column(COL::SOURCE_DATA_RELEASE_COLLECTION_PERIOD_START)
+            .unwrap()
+            .iter(),
+        df_to_show
+            .column(COL::COUNTRY_NAME_SHORT_EN)
+            .unwrap()
+            .iter(),
         df_to_show.column(COL::GEOMETRY_LEVEL).unwrap().iter(),
     ) {
         let mut table = Table::new();
+        debug!("{:#?}", country);
         table
             .load_preset(NOTHING)
             .set_content_arrangement(ContentArrangement::Dynamic)
@@ -41,6 +51,14 @@ pub fn display_search_results(results: SearchResults, max_results: Option<usize>
             .add_row(vec![
                 Cell::new("HXL tag").add_attribute(Attribute::Bold),
                 hxl.get_str().unwrap().into(),
+            ])
+            .add_row(vec![
+                Cell::new("Collection date").add_attribute(Attribute::Bold),
+                format!("{date}").into(),
+            ])
+            .add_row(vec![
+                Cell::new("Country").add_attribute(Attribute::Bold),
+                country.get_str().unwrap().into(),
             ])
             .add_row(vec![
                 Cell::new("Geometry level").add_attribute(Attribute::Bold),

--- a/src/display.rs
+++ b/src/display.rs
@@ -1,6 +1,6 @@
 use comfy_table::{presets::NOTHING, *};
 use itertools::izip;
-use log::debug;
+
 use popgetter::{search::SearchResults, COL};
 
 pub fn display_search_results(

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -109,9 +109,15 @@ impl Metadata {
                 [col(COL::SOURCE_DATA_RELEASE_DATA_PUBLISHER_ID)],
                 [col(COL::DATA_PUBLISHER_ID)],
                 JoinArgs::new(JoinType::Inner),
+            )
+            // TODO: consider case when many countries
+            .explode([col(COL::DATA_PUBLISHER_COUNTRIES_OF_INTEREST)])
+            .join(
+                self.countries.clone().lazy(),
+                [col(COL::DATA_PUBLISHER_COUNTRIES_OF_INTEREST)],
+                [col(COL::COUNTRY_ID)],
+                JoinArgs::new(JoinType::Inner),
             );
-        // TODO: Add a country_id column to the metadata, and merge in the countries as well. See
-        // https://github.com/Urban-Analytics-Technology-Platform/popgetter/issues/104
 
         // Debug print the column names so that we know what we can access
         let schema = df.schema().unwrap();

--- a/src/search.rs
+++ b/src/search.rs
@@ -374,8 +374,7 @@ impl SearchResults {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
+    // use super::*;
     // #[test]
     // fn test_search_request() {
     //     let mut sr = SearchRequest{search_string: None}.with_country("a").with_country("b");


### PR DESCRIPTION
Closes #55.

- Adds country names when joining metadata and implements filtering from CLI (currently `COUNTRY_NAME_SHORT_EN`).
- Renames binary as `popgetter`