### PR TITLE
Additions and revisions for v0.2.0 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2696,7 +2696,7 @@ dependencies = [
 
 [[package]]
 name = "popgetter_cli"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "popgetter_cli"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 [lib]

--- a/README.md
+++ b/README.md
@@ -2,17 +2,27 @@
 
 Library and associated command-line application for exploring and fetching [popgetter](https://github.com/Urban-Analytics-Technology-Platform/popgetter) data.
 
+## Quickstart
+
+- Install [Rust](https://www.rust-lang.org/tools/install)
+- Install CLI:
+  ```shell
+  cargo install --git https://github.com/Urban-Analytics-Technology-Platform/popgetter-cli.git
+  ```
+- Run the CLI with e.g.:
+  ```shell
+  popgetter --help
+  ```
 
 ### Popgetter version compatibility
 
 Each version of `popgetter-cli` is tied to one specific version of `popgetter` to ensure consistency of data _types_.
 (Note that updates to the actual data and metadata themselves do not lead to a version bump.)
 
-| popgetter    | popgetter-cli |
-|--------------|---------------|
-| 0.1.0        | 0.1.0         |
-| ...          | ...           |
-
+| popgetter | popgetter-cli |
+| --------- | ------------- |
+| 0.1.0     | 0.1.0         |
+| ...       | ...           |
 
 ## Developer notes
 

--- a/README.md
+++ b/README.md
@@ -21,20 +21,6 @@ Each version of `popgetter-cli` is tied to one specific version of `popgetter` t
 
 | popgetter | popgetter-cli |
 | --------- | ------------- |
-| 0.1.0     |          |
+| 0.1.0     |               |
 | 0.2.0     | 0.2.0         |
 | ...       | ...           |
-
-## Developer notes
-
-### Updating popgetter types
-
-`popgetter-cli` depends on type-level information _about_ the data and metadata it consumes, i.e. what fields are present and what types they have.
-This information is stored as a JSON schema in the `schema` subdirectory of this repository.
-To generate this file, install the appropriate version of the `popgetter` library locally (see version table [above](#popgetter-version-compatibility)), and then run
-
-```
-popgetter-export-schema ./schema
-```
-
-from the top level of this repository.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ Each version of `popgetter-cli` is tied to one specific version of `popgetter` t
 
 | popgetter | popgetter-cli |
 | --------- | ------------- |
-| 0.1.0     | 0.1.0         |
+| 0.1.0     |          |
+| 0.2.0     | 0.2.0         |
 | ...       | ...           |
 
 ## Developer notes

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -139,7 +139,7 @@ impl RunCommand for DataCommand {
         let search_results = popgetter.search(self.search_params_args.clone().into());
 
         // Make DataRequestSpec
-        // TODO: possibly implement From<(DataCommand, SearchParams)> for DataRequestSpec
+        // TODO: consider alternative `From` impls as part of #67
         let data_request_spec = self.into();
 
         // sp.stop_and_persist is potentially a better method, but not obvious how to
@@ -189,7 +189,7 @@ impl RunCommand for DataCommand {
 /// The set of ways to search will likley increase over time
 #[derive(Args, Debug)]
 pub struct MetricsCommand {
-    // TODO: consider implementation of bbox as part of:
+    // TODO: consider implementation of bbox for metrics subcommand as part of:
     // [#67](https://github.com/Urban-Analytics-Technology-Platform/popgetter-cli/issues/67)
     // #[arg(
     //     short,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -393,7 +393,7 @@ impl RunCommand for SurveysCommand {
 
 /// The entrypoint for the CLI.
 #[derive(Parser, Debug)]
-#[command(version, about, long_about = None, name="popgetter", long_about="Popgetter is a tool to quickly get the data you need!")]
+#[command(version, about="Popgetter is a tool to quickly get the data you need!", long_about = None, name="popgetter")]
 pub struct Cli {
     #[command(subcommand)]
     pub command: Option<Commands>,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -11,6 +11,7 @@ use popgetter::{
         CSVFormatter, GeoJSONFormatter, GeoJSONSeqFormatter, OutputFormatter, OutputGenerator,
     },
     geo::BBox,
+    metadata::get_country_names,
     search::{
         Country, DataPublisher, GeometryLevel, MetricId, SearchContext, SearchParams,
         SearchResults, SearchText, SourceDataRelease, SourceMetricId, YearRange,
@@ -340,7 +341,12 @@ pub struct CountriesCommand;
 
 impl RunCommand for CountriesCommand {
     async fn run(&self, config: Config) -> Result<()> {
-        let _popgetter = Popgetter::new_with_config(config).await?;
+        let popgetter = Popgetter::new_with_config(config).await?;
+        println!("The following countries are available:");
+        get_country_names(&popgetter.config)
+            .await?
+            .into_iter()
+            .for_each(|country| println!("{country}"));
         Ok(())
     }
 }
@@ -353,12 +359,12 @@ pub struct SurveysCommand;
 impl RunCommand for SurveysCommand {
     async fn run(&self, _config: Config) -> Result<()> {
         info!("Running `surveys` subcommand");
-        Ok(())
+        unimplemented!("The `Surveys` subcommand is not implemented for the current release");
     }
 }
 
-/// The Recipe command loads a recipe file and generates the output data requested
-/// TODO: Reimplement this
+// // TODO: Reimplement this
+// /// The Recipe command loads a recipe file and generates the output data requested
 // #[derive(Args, Debug)]
 // pub struct RecipeCommand {
 //     #[arg(index = 1)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -55,9 +55,16 @@ pub struct DataCommand {
     #[arg(
         short,
         long,
-        value_name = "MIN_LNG,MIN_LAT,MAX_LNG,MAX_LAT",
+        value_name = "LEFT,BOTTOM,RIGHT,TOP",
         allow_hyphen_values = true,
-        help = "Bounding box in which to get the results"
+        help = "\
+Bounding box in which to get the results. The bounding box provided must be in\n\
+the same coordinate system as used in the requested geometry file. For\n\
+example, United States has geometries with latitude and longitude (EPSG:4326),\n\
+Great Britain has geometries with the British National Grid (EPSG:27700),\n\
+Northern Ireland has geometries with the Irish Grid (EPSG:29902), and\n\
+Beligum has geometries with the Belgian Lambert 2008 reference system\n\
+(EPSG:3812)."
     )]
     bbox: Option<BBox>,
     #[arg(
@@ -194,9 +201,9 @@ pub struct MetricsCommand {
     // #[arg(
     //     short,
     //     long,
-    //     value_name = "MIN_LNG,MIN_LAT,MAX_LNG,MAX_LAT",
+    //     value_name = "LEFT,BOTTOM,RIGHT,TOP",
     //     allow_hyphen_values=true,
-    //     help = "Bounding box in which to get the results"
+    //       help = "TODO"
     // )]
     // bbox: Option<BBox>,
     #[arg(
@@ -220,7 +227,9 @@ struct SearchParamsArgs {
     #[arg(
         short,
         long,
-        help = "Filter by year ranges. All ranges are inclusive; multiple ranges can be comma-separated.",
+        help = "\
+Filter by year ranges. All ranges are inclusive; multiple ranges can be\n\
+comma-separated.",
         value_name = "YEAR|START...|...END|START...END",
         value_parser = parse_year_range,
     )]
@@ -235,7 +244,9 @@ struct SearchParamsArgs {
     country: Option<String>,
     #[arg(
         long,
-        help = "Filter by source metric ID (i.e. the name of the table in the original data release)"
+        help = "\
+Filter by source metric ID (i.e. the name of the table in the original data\n\
+release)."
     )]
     source_metric_id: Option<String>,
     #[arg(

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,9 +9,7 @@ pub struct Config {
 impl Default for Config {
     fn default() -> Self {
         Config {
-            base_path:
-                "https://popgetter.blob.core.windows.net/popgetter-dagster-test/test_v2_release"
-                    .into(),
+            base_path: "https://popgetter.blob.core.windows.net/releases/v0.2.0".into(),
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,7 +9,9 @@ pub struct Config {
 impl Default for Config {
     fn default() -> Self {
         Config {
-            base_path: "https://popgetter.blob.core.windows.net/releases/v0.2.0".into(),
+            // TODO: add fn to generate the release directory name from the CLI version directly
+            // E.g. this could be achieved with: https://docs.rs/built/latest/built/
+            base_path: "https://popgetter.blob.core.windows.net/releases/v0.2".into(),
         }
     }
 }

--- a/src/data_request_spec.rs
+++ b/src/data_request_spec.rs
@@ -1,0 +1,149 @@
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+use std::{
+    ops::{Index, IndexMut},
+    str::FromStr,
+};
+
+use crate::{parquet::MetricRequest, search::MetricId};
+
+#[derive(Serialize, Deserialize, Debug, Default)]
+pub struct DataRequestSpec {
+    pub geometry: GeometrySpec,
+    pub region: Vec<RegionSpec>,
+    pub metrics: Vec<MetricSpec>,
+    pub years: Option<Vec<String>>,
+}
+
+#[derive(Debug)]
+pub struct MetricRequestResult {
+    pub metrics: Vec<MetricRequest>,
+    pub selected_geometry: String,
+    pub years: Vec<String>,
+}
+
+// impl DataRequestSpec {
+//     /// Generates a vector of metric requests from a `DataRequestSpec` and a catalogue.
+//     pub fn metric_requests(
+//         &self,
+//         catalogue: &Metadata,
+//         config: &Config,
+//     ) -> Result<MetricRequestResult> {
+//         // Find all the metrics which match the requested ones, expanding
+//         // any regex matches as we do so
+//         let expanded_metric_ids: Vec<MetricId> = self
+//             .metrics
+//             .iter()
+//             .filter_map(|metric_spec| match metric_spec {
+//                 MetricSpec::Metric(id) => catalogue.expand_regex_metric(id).ok(),
+//                 MetricSpec::DataProduct(_) => None,
+//             })
+//             .flatten()
+//             .collect::<Vec<_>>();
+
+//         let full_selection_plan =
+//             catalogue.generate_selection_plan(&expanded_metric_ids, &self.geometry, &self.years)?;
+
+//         info!("Running your query with \n {full_selection_plan}");
+
+//         let metric_requests =
+//             catalogue.get_metric_requests(full_selection_plan.explicit_metric_ids, config)?;
+
+//         Ok(MetricRequestResult {
+//             metrics: metric_requests,
+//             selected_geometry: full_selection_plan.geometry,
+//             years: full_selection_plan.year,
+//         })
+//     }
+// }
+
+#[derive(Serialize, Deserialize, Debug)]
+pub enum MetricSpec {
+    Metric(MetricId),
+    DataProduct(String),
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct GeometrySpec {
+    pub geometry_level: Option<String>,
+    pub include_geoms: bool,
+}
+
+impl Default for GeometrySpec {
+    fn default() -> Self {
+        Self {
+            include_geoms: true,
+            geometry_level: None,
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub enum RegionSpec {
+    BoundingBox(BBox),
+    Polygon(Polygon),
+    NamedArea(String),
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct Polygon;
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct BBox(pub [f64; 4]);
+
+impl Index<usize> for BBox {
+    type Output = f64;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.0[index]
+    }
+}
+
+impl IndexMut<usize> for BBox {
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        &mut self.0[index]
+    }
+}
+
+impl FromStr for BBox {
+    type Err = &'static str;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        let parts: Vec<f64> = value
+            .split(',')
+            .map(|s| s.trim().parse::<f64>().map_err(|_| "Failed to parse bbox"))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        if parts.len() != 4 {
+            return Err("Bounding boxes need to have 4 coords");
+        }
+        let mut bbox = [0.0; 4];
+        bbox.copy_from_slice(&parts);
+        Ok(BBox(bbox))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn bbox_should_parse_if_correct() {
+        let bbox = BBox::from_str("0.0,1.0,2.0,3.0");
+        assert!(bbox.is_ok(), "A four coord bbox should parse");
+    }
+
+    #[test]
+    fn bbox_should_not_parse_if_incorrect() {
+        let bbox = BBox::from_str("0.0,1.0,2.0");
+        assert!(
+            bbox.is_err(),
+            "A string with fewer than 4 coords should not parse"
+        );
+        let bbox = BBox::from_str("0.0,1.0,2.0,3.0,4.0");
+        assert!(
+            bbox.is_err(),
+            "A string with 5 or more coords should not parse"
+        );
+        let bbox = BBox::from_str("0.0sdfsd,1.0,2.0");
+        assert!(bbox.is_err(), "A string with letters shouldn't parse");
+    }
+}

--- a/src/data_request_spec.rs
+++ b/src/data_request_spec.rs
@@ -97,31 +97,4 @@ impl RegionSpec {
 pub struct Polygon;
 
 #[cfg(test)]
-mod tests {
-
-    use std::str::FromStr;
-
-    use super::*;
-
-    #[test]
-    fn bbox_should_parse_if_correct() {
-        let bbox = BBox::from_str("0.0,1.0,2.0,3.0");
-        assert!(bbox.is_ok(), "A four coord bbox should parse");
-    }
-
-    #[test]
-    fn bbox_should_not_parse_if_incorrect() {
-        let bbox = BBox::from_str("0.0,1.0,2.0");
-        assert!(
-            bbox.is_err(),
-            "A string with fewer than 4 coords should not parse"
-        );
-        let bbox = BBox::from_str("0.0,1.0,2.0,3.0,4.0");
-        assert!(
-            bbox.is_err(),
-            "A string with 5 or more coords should not parse"
-        );
-        let bbox = BBox::from_str("0.0sdfsd,1.0,2.0");
-        assert!(bbox.is_err(), "A string with letters shouldn't parse");
-    }
-}
+mod tests {}

--- a/src/display.rs
+++ b/src/display.rs
@@ -1,7 +1,56 @@
 use comfy_table::{presets::NOTHING, *};
 use itertools::izip;
 
+use polars::{frame::DataFrame, prelude::SortMultipleOptions};
 use popgetter::{search::SearchResults, COL};
+
+pub fn display_countries(countries: DataFrame, max_results: Option<usize>) -> anyhow::Result<()> {
+    let df_to_show = match max_results {
+        Some(max) => countries.head(Some(max)),
+        None => countries,
+    };
+    let df_to_show = df_to_show.sort([COL::COUNTRY_ID], SortMultipleOptions::default())?;
+    let mut table = Table::new();
+    table
+        .load_preset(NOTHING)
+        .set_content_arrangement(ContentArrangement::Dynamic)
+        .set_header(vec![
+            Cell::new("Country ID").add_attribute(Attribute::Bold),
+            Cell::new("Country Name (official)").add_attribute(Attribute::Bold),
+            Cell::new("Country Name (short)").add_attribute(Attribute::Bold),
+            Cell::new("ISO3116-1 alpha-3").add_attribute(Attribute::Bold),
+            Cell::new("ISO3116-2").add_attribute(Attribute::Bold),
+        ])
+        .set_style(comfy_table::TableComponent::BottomBorder, '─')
+        .set_style(comfy_table::TableComponent::MiddleHeaderIntersections, '─')
+        .set_style(comfy_table::TableComponent::HeaderLines, '─')
+        .set_style(comfy_table::TableComponent::BottomBorderIntersections, '─')
+        .set_style(comfy_table::TableComponent::TopBorder, '─')
+        .set_style(comfy_table::TableComponent::TopBorderIntersections, '─');
+    for (
+        country_id,
+        country_name_official,
+        country_name_short_en,
+        countr_iso3,
+        country_iso3116_2,
+    ) in izip!(
+        df_to_show.column(COL::COUNTRY_ID)?.str()?,
+        df_to_show.column(COL::COUNTRY_NAME_OFFICIAL)?.str()?,
+        df_to_show.column(COL::COUNTRY_NAME_SHORT_EN)?.str()?,
+        df_to_show.column(COL::COUNTRY_ISO3)?.str()?,
+        df_to_show.column(COL::COUNTRY_ISO3166_2)?.str()?,
+    ) {
+        table.add_row(vec![
+            country_id.unwrap_or_default(),
+            country_name_official.unwrap_or_default(),
+            country_name_short_en.unwrap_or_default(),
+            countr_iso3.unwrap_or_default(),
+            country_iso3116_2.unwrap_or_default(),
+        ]);
+    }
+    println!("\n{}", table);
+    Ok(())
+}
 
 pub fn display_search_results(
     results: SearchResults,

--- a/src/geo.rs
+++ b/src/geo.rs
@@ -15,7 +15,7 @@ use std::{
 /// `bbox`: an optional bounding box to filter the features by
 ///
 /// Returns: a Result object containing a vector of (geometry, properties).
-pub async fn get_geometries(file_url: &str, bbox: Option<&BBox>) -> Result<DataFrame> {
+pub async fn get_geometries(file_url: &str, bbox: Option<BBox>) -> Result<DataFrame> {
     let fgb = HttpFgbReader::open(file_url).await?;
 
     let mut fgb = if let Some(bbox) = bbox {
@@ -235,7 +235,7 @@ mod tests {
             -1.373_095_490_899_146_4,
             53.026_908_220_355_35,
         ]);
-        let geoms = get_geometries(&server.url("/fgb_example.fgb"), Some(&bbox)).await;
+        let geoms = get_geometries(&server.url("/fgb_example.fgb"), Some(bbox)).await;
 
         assert!(geoms.is_ok(), "The geometry call should not error");
         let geoms = geoms.unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ pub use column_names as COL;
 // Modules
 pub mod column_names;
 pub mod config;
+pub mod data_request_spec;
 pub mod error;
 #[cfg(feature = "formatters")]
 pub mod formatters;

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,10 +7,14 @@ use cli::{Cli, RunCommand};
 use log::debug;
 use popgetter::config::Config;
 
+const DEFAULT_LOGGING_LEVEL: &str = "warn";
+
 #[tokio::main]
 async fn main() -> Result<()> {
+    // Set RUST_LOG to `DEFAULT_LOGGING_LEVEL` if not set
+    let _ =
+        std::env::var("RUST_LOG").map_err(|_| std::env::set_var("RUST_LOG", DEFAULT_LOGGING_LEVEL));
     pretty_env_logger::init_timed();
-
     let args = Cli::parse();
     debug!("args: {args:?}");
     let config: Config = read_config_from_toml();

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -172,10 +172,9 @@ impl CountryMetadataLoader {
     }
 }
 
-pub async fn get_country_names(config: &Config) -> anyhow::Result<Vec<String>> {
-    let country_text_file = format!("{}/countries.txt", config.base_path);
+async fn get_country_names(config: &Config) -> anyhow::Result<Vec<String>> {
     Ok(reqwest::Client::new()
-        .get(&country_text_file)
+        .get(&format!("{}/countries.txt", config.base_path))
         .send()
         .await?
         .text()

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -172,11 +172,9 @@ impl CountryMetadataLoader {
     }
 }
 
-/// Load the metadata for a list of countries and merge them into
-/// a single `Metadata` catalogue.
-pub async fn load_all(config: &Config) -> Result<Metadata> {
+pub async fn get_country_names(config: &Config) -> anyhow::Result<Vec<String>> {
     let country_text_file = format!("{}/countries.txt", config.base_path);
-    let country_names: Vec<String> = reqwest::Client::new()
+    Ok(reqwest::Client::new()
         .get(&country_text_file)
         .send()
         .await?
@@ -184,9 +182,15 @@ pub async fn load_all(config: &Config) -> Result<Metadata> {
         .await?
         .lines()
         .map(|s| s.to_string())
-        .collect();
-    info!("Detected country names: {:?}", country_names);
+        .collect())
+}
 
+/// Load the metadata for a list of countries and merge them into
+/// a single `Metadata` catalogue.
+pub async fn load_all(config: &Config) -> Result<Metadata> {
+    let country_names = get_country_names(config).await?;
+
+    info!("Detected country names: {:?}", country_names);
     let metadata: Result<Vec<Metadata>> = join_all(
         country_names
             .iter()

--- a/src/search.rs
+++ b/src/search.rs
@@ -3,7 +3,7 @@
 use crate::{
     config::Config,
     data_request_spec::DataRequestSpec,
-    geo::{get_geometries, BBox},
+    geo::get_geometries,
     metadata::ExpandedMetadata,
     parquet::{get_metrics, MetricRequest},
     COL,
@@ -308,11 +308,6 @@ impl From<SearchParams> for Option<Expr> {
 #[derive(Clone, Debug)]
 pub struct SearchResults(pub DataFrame);
 
-pub(crate) struct DownloadConfig {
-    pub bbox: Option<BBox>,
-    pub include_geometry: bool,
-}
-
 impl SearchResults {
     /// Convert all the metrics in the dataframe to MetricRequests
     pub fn to_metric_requests(self, config: &Config) -> Vec<MetricRequest> {
@@ -374,12 +369,25 @@ impl SearchResults {
 
         // TODO Handle multiple responses
         if all_geom_files.len() > 1 {
-            panic!("Multiple geometries not yet supported");
+            todo!("Multiple geometries not yet supported");
         }
 
         let result = if data_request_spec.geometry.include_geoms {
             // TODO Pass in the bbox as the second argument here
-            let geoms = get_geometries(all_geom_files.iter().next().unwrap(), None);
+            if data_request_spec.region.len() > 1 {
+                todo!(
+                    "Multiple region specifications are not yet supported: {:#?}",
+                    data_request_spec.region
+                );
+            }
+            debug!("{:#?}", data_request_spec.region.first().unwrap().bbox());
+            let geoms = get_geometries(
+                all_geom_files.iter().next().unwrap(),
+                data_request_spec
+                    .region
+                    .first()
+                    .and_then(|region_spec| region_spec.bbox().clone()),
+            );
 
             // try_join requires us to have the errors from all futures be the same.
             // We use anyhow to get it back properly

--- a/src/search.rs
+++ b/src/search.rs
@@ -160,7 +160,18 @@ impl From<GeometryLevel> for Expr {
 
 impl From<Country> for Expr {
     fn from(value: Country) -> Self {
-        case_insensitive_contains(COL::COUNTRY_NAME_SHORT_EN, &value.0)
+        combine_exprs_with_or(vec![
+            case_insensitive_contains(COL::COUNTRY_NAME_SHORT_EN, &value.0),
+            case_insensitive_contains(COL::COUNTRY_NAME_OFFICIAL, &value.0),
+            case_insensitive_contains(COL::COUNTRY_ISO2, &value.0),
+            case_insensitive_contains(COL::COUNTRY_ISO3, &value.0),
+            case_insensitive_contains(COL::COUNTRY_ISO3166_2, &value.0),
+            // TODO: add `COUNTRY_ID` for ExpandedMetadata
+            // case_insensitive_contains(COL::COUNTRY_ID, &value.0),
+            case_insensitive_contains(COL::DATA_PUBLISHER_COUNTRIES_OF_INTEREST, &value.0),
+        ])
+        // Unwrap: cannot be None as vec above is non-empty
+        .unwrap()
     }
 }
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -369,7 +369,7 @@ impl SearchResults {
 
         // TODO Handle multiple responses
         if all_geom_files.len() > 1 {
-            todo!("Multiple geometries not yet supported");
+            unimplemented!("Multiple geometries not supported in current release");
         }
 
         let result = if data_request_spec.geometry.include_geoms {
@@ -380,7 +380,6 @@ impl SearchResults {
                     data_request_spec.region
                 );
             }
-            debug!("{:#?}", data_request_spec.region.first().unwrap().bbox());
             let geoms = get_geometries(
                 all_geom_files.iter().next().unwrap(),
                 data_request_spec

--- a/src/search.rs
+++ b/src/search.rs
@@ -9,7 +9,7 @@ use crate::{
     COL,
 };
 use chrono::NaiveDate;
-use log::debug;
+use log::{debug, warn};
 use nonempty::{nonempty, NonEmpty};
 use polars::lazy::dsl::{col, lit, Expr};
 use polars::prelude::{DataFrame, DataFrameJoinOps, IntoLazy, LazyFrame};
@@ -380,13 +380,15 @@ impl SearchResults {
                     data_request_spec.region
                 );
             }
-            let geoms = get_geometries(
-                all_geom_files.iter().next().unwrap(),
-                data_request_spec
-                    .region
-                    .first()
-                    .and_then(|region_spec| region_spec.bbox().clone()),
-            );
+            let bbox = data_request_spec
+                .region
+                .first()
+                .and_then(|region_spec| region_spec.bbox().clone());
+
+            if bbox.is_some() {
+                warn!("The bounding box should be specified in the same coordinate system as the requested geometry.")
+            }
+            let geoms = get_geometries(all_geom_files.iter().next().unwrap(), bbox);
 
             // try_join requires us to have the errors from all futures be the same.
             // We use anyhow to get it back properly

--- a/src/search.rs
+++ b/src/search.rs
@@ -386,7 +386,10 @@ impl SearchResults {
                 .and_then(|region_spec| region_spec.bbox().clone());
 
             if bbox.is_some() {
-                warn!("The bounding box should be specified in the same coordinate system as the requested geometry.")
+                warn!(
+                    "The bounding box should be specified in the same coordinate reference system \
+                     as the requested geometry."
+                )
             }
             let geoms = get_geometries(all_geom_files.iter().next().unwrap(), bbox);
 


### PR DESCRIPTION
Closes #58.

This adds:
- Fix conflicting help messages
- BBox for `Data` subcommand
- `--no-geometry` option to exclude geometries from request
- Impl of `countries` subcommand
- Quickstart
- Adds quiet mode without progress bar/spinner to optionally enable logs to readable