### PR TITLE
Reimplement recipe subcommand

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 .DS_Store
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 .DS_Store
 .vscode
+popgetter_py

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -600,7 +600,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2139,7 +2139,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2721,6 +2721,7 @@ dependencies = [
  "spinners",
  "strum 0.26.2",
  "strum_macros 0.26.4",
+ "tempfile",
  "thiserror",
  "tokio",
  "toml",
@@ -3687,14 +3688,15 @@ checksum = "c1bbb9f3c5c463a01705937a24fdabc5047929ac764b2d5b9cf681c1f5041ed5"
 
 [[package]]
 name = "tempfile"
-version = "3.10.1"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
+checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
 dependencies = [
  "cfg-if",
  "fastrand 2.1.0",
+ "once_cell",
  "rustix 0.38.34",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4222,7 +4224,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
 dependencies = [
  "windows-core",
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4231,7 +4233,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4249,7 +4251,16 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4269,18 +4280,18 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.5",
- "windows_aarch64_msvc 0.52.5",
- "windows_i686_gnu 0.52.5",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.5",
- "windows_x86_64_gnu 0.52.5",
- "windows_x86_64_gnullvm 0.52.5",
- "windows_x86_64_msvc 0.52.5",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -4291,9 +4302,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -4303,9 +4314,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4315,15 +4326,15 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -4333,9 +4344,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4345,9 +4356,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -4357,9 +4368,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -4369,9 +4380,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,20 +14,30 @@ path = "src/main.rs"
 [dependencies]
 anyhow = "1.0.75"
 serde = { version = "1.0", features = ["derive"] }
-serde_json = {version="1.0"}
+serde_json = { version = "1.0" }
 tokio = { version = "1.30.0", features = ["full"] }
 clap = { version = "4.5.0", features = ["derive"] }
-polars = {version ="0.39.2", features = ["lazy","is_in","http","streaming", "parquet","polars-io","regex","strings","rows"]}
+polars = { version = "0.39.2", features = [
+    "lazy",
+    "is_in",
+    "http",
+    "streaming",
+    "parquet",
+    "polars-io",
+    "regex",
+    "strings",
+    "rows",
+] }
 typify = "0.0.16"
-chrono = {version="0.4.37", features=['serde']}
-reqwest = {version = "0.12.3", features = ["json"]}
+chrono = { version = "0.4.37", features = ['serde'] }
+reqwest = { version = "0.12.3", features = ["json"] }
 strum = "0.26"
 strum_macros = "0.26"
 enum_dispatch = "0.3"
 flatgeobuf = "~4.1.0"
-geozero = {version = "0.12.0", features= ["with-csv","with-geojson"]}
+geozero = { version = "0.12.0", features = ["with-csv", "with-geojson"] }
 httpmock = "0.7.0-rc.1"
-geojson={version="0.24.1", optional=true }
+geojson = { version = "0.24.1", optional = true }
 geo = "0.28.0"
 wkt = "0.10.3"
 wkb = "0.7.1"
@@ -43,7 +53,10 @@ thiserror = "1"
 nonempty = { version = "0.10.0", features = ["serialize"] }
 spinners = "4.1.1"
 
+[dev-dependencies]
+tempfile = "3.12"
+
 
 [features]
 default = ["formatters"]
-formatters= ["dep:geojson"]
+formatters = ["dep:geojson"]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -105,7 +105,9 @@ struct DownloadParamsArgs {
     no_geometry: bool,
 }
 
-#[derive(Clone)]
+/// A type combining both the `SearchParamsArgs` and `DownloadParamsArgs` to enable `DownloadParams`
+/// to be constructed since fields of `SearchParamsArgs` may also be needed for `DownloadParams`.
+#[derive(Clone, Debug)]
 struct CombinedParamsArgs {
     search_params_args: SearchParamsArgs,
     download_params_args: DownloadParamsArgs,
@@ -167,7 +169,6 @@ impl RunCommand for DataCommand {
             search_params_args: self.search_params_args.clone(),
             download_params_args: self.download_params_args.clone(),
         }
-        .clone()
         .into();
 
         if !self.force_run {
@@ -360,7 +361,7 @@ impl RunCommand for MetricsCommand {
             )
         });
         let popgetter = Popgetter::new_with_config(config).await?;
-        let search_results = popgetter.search(&self.search_params_args.clone().into());
+        let search_results = popgetter.search(&self.search_params_args.to_owned().into());
         if let Some(mut s) = sp {
             s.stop_with_symbol(COMPLETE_PROGRESS_STRING);
         }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -389,7 +389,6 @@ impl RunCommand for SurveysCommand {
     }
 }
 
-// // TODO: Reimplement this
 /// The Recipe command loads a recipe file and generates the output data requested
 #[derive(Args, Debug)]
 pub struct RecipeCommand {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -142,7 +142,7 @@ impl RunCommand for DataCommand {
         });
         let popgetter = Popgetter::new_with_config(config).await?;
         let search_params: SearchParams = self.search_params_args.clone().into();
-        let search_results = popgetter.search(search_params.clone());
+        let search_results = popgetter.search(&search_params);
 
         // sp.stop_and_persist is potentially a better method, but not obvious how to
         // store the timing. Leaving below until that option is ruled out.
@@ -343,7 +343,7 @@ impl RunCommand for MetricsCommand {
             )
         });
         let popgetter = Popgetter::new_with_config(config).await?;
-        let search_results = popgetter.search(self.search_params_args.clone().into());
+        let search_results = popgetter.search(&self.search_params_args.clone().into());
         if let Some(mut s) = sp {
             s.stop_with_symbol(COMPLETE_PROGRESS_STRING);
         }
@@ -423,7 +423,7 @@ impl RunCommand for RecipeCommand {
         let recipe = std::fs::read_to_string(&self.recipe_file)?;
         let data_request: DataRequestSpec = serde_json::from_str(&recipe)?;
         let params: Params = data_request.try_into()?;
-        let search_results = popgetter.search(params.search.clone());
+        let search_results = popgetter.search(&params.search);
 
         let data = search_results
             .download(&popgetter.config, &params.search, &params.download)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -466,6 +466,17 @@ mod tests {
 
     use super::*;
 
+    #[tokio::test]
+    async fn test_recipe_command() {
+        let recipe_command = RecipeCommand {
+            recipe_file: format!("{}/test_recipe.json", env!("CARGO_MANIFEST_DIR")),
+            output_format: OutputFormat::GeoJSON,
+            output_file: None,
+        };
+        let result = recipe_command.run(Config::default()).await;
+        assert!(result.is_ok())
+    }
+
     #[test]
     fn test_parse_year_range() {
         assert_eq!(

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -130,10 +130,6 @@ impl RunCommand for DataCommand {
         let search_params: SearchParams = self.search_params_args.clone().into();
         let search_results = popgetter.search(search_params.clone());
 
-        // Make DataRequestSpec
-        // TODO: consider alternative `From` impls as part of #67
-        // let data_request_config: DataRequestConfig = (self, &search_params).into();
-
         // sp.stop_and_persist is potentially a better method, but not obvious how to
         // store the timing. Leaving below until that option is ruled out.
         // sp.stop_and_persist(&COMPLETE_PROGRESS_STRING, spinner_message.into());

--- a/src/data_request_spec.rs
+++ b/src/data_request_spec.rs
@@ -8,7 +8,7 @@ use crate::search::{
     YearRange,
 };
 
-#[derive(Serialize, Deserialize, Debug, Default)]
+#[derive(Serialize, Deserialize, Clone, Debug, Default)]
 pub struct DataRequestSpec {
     pub geometry: Option<GeometrySpec>,
     pub region: Vec<RegionSpec>,
@@ -75,14 +75,14 @@ impl TryFrom<DataRequestSpec> for Params {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Clone, Serialize, Deserialize, Debug)]
 pub enum MetricSpec {
     MetricId(MetricId),
     MetricText(String),
     DataProduct(String),
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct GeometrySpec {
     pub geometry_level: Option<String>,
     pub include_geoms: bool,

--- a/src/data_request_spec.rs
+++ b/src/data_request_spec.rs
@@ -1,6 +1,3 @@
-// TODO: this module to be refactored following implementation of SearchParams.
-// See [#67](https://github.com/Urban-Analytics-Technology-Platform/popgetter-cli/issues/67)
-
 use itertools::Itertools;
 use nonempty::nonempty;
 use serde::{Deserialize, Serialize};
@@ -77,48 +74,6 @@ impl TryFrom<DataRequestSpec> for Params {
         })
     }
 }
-
-// #[derive(Debug)]
-// pub struct MetricRequestResult {
-//     pub metrics: Vec<MetricRequest>,
-//     pub selected_geometry: String,
-//     pub years: Vec<String>,
-// }
-//
-// impl DataRequestSpec {
-//     /// Generates a vector of metric requests from a `DataRequestSpec` and a catalogue.
-//     pub fn metric_requests(
-//         &self,
-//         catalogue: &Metadata,
-//         config: &Config,
-//     ) -> Result<MetricRequestResult> {
-//         // Find all the metrics which match the requested ones, expanding
-//         // any regex matches as we do so
-//         let expanded_metric_ids: Vec<MetricId> = self
-//             .metrics
-//             .iter()
-//             .filter_map(|metric_spec| match metric_spec {
-//                 MetricSpec::Metric(id) => catalogue.expand_regex_metric(id).ok(),
-//                 MetricSpec::DataProduct(_) => None,
-//             })
-//             .flatten()
-//             .collect::<Vec<_>>();
-
-//         let full_selection_plan =
-//             catalogue.generate_selection_plan(&expanded_metric_ids, &self.geometry, &self.years)?;
-
-//         info!("Running your query with \n {full_selection_plan}");
-
-//         let metric_requests =
-//             catalogue.get_metric_requests(full_selection_plan.explicit_metric_ids, config)?;
-
-//         Ok(MetricRequestResult {
-//             metrics: metric_requests,
-//             selected_geometry: full_selection_plan.geometry,
-//             years: full_selection_plan.year,
-//         })
-//     }
-// }
 
 #[derive(Serialize, Deserialize, Debug)]
 pub enum MetricSpec {

--- a/src/data_request_spec.rs
+++ b/src/data_request_spec.rs
@@ -19,6 +19,8 @@ pub struct DataRequestSpec {
     pub years: Option<Vec<String>>,
 }
 
+// Since `DataRequestSpec` contains parameters relevant to both `SearchParams` and `DownloadParams`,
+// the conversion is implemented for `Params`.
 impl TryFrom<DataRequestSpec> for Params {
     type Error = anyhow::Error;
     fn try_from(value: DataRequestSpec) -> Result<Self, Self::Error> {

--- a/src/data_request_spec.rs
+++ b/src/data_request_spec.rs
@@ -4,7 +4,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::geo::BBox;
-use crate::search::MetricId;
+use crate::search::{MetricId, SearchParams};
 
 #[derive(Serialize, Deserialize, Debug, Default)]
 pub struct DataRequestSpec {
@@ -12,6 +12,12 @@ pub struct DataRequestSpec {
     pub region: Vec<RegionSpec>,
     pub metrics: Vec<MetricSpec>,
     pub years: Option<Vec<String>>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Default)]
+pub struct DataRequestConfig {
+    pub include_geoms: bool,
+    pub region_spec: Vec<RegionSpec>,
 }
 
 // #[derive(Debug)]
@@ -77,7 +83,7 @@ impl Default for GeometrySpec {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Clone, Serialize, Deserialize, Debug)]
 pub enum RegionSpec {
     BoundingBox(BBox),
     Polygon(Polygon),
@@ -93,7 +99,7 @@ impl RegionSpec {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct Polygon;
 
 #[cfg(test)]

--- a/src/data_request_spec.rs
+++ b/src/data_request_spec.rs
@@ -27,7 +27,7 @@ impl TryFrom<DataRequestSpec> for Params {
         // TODO: handle MetricSpec::DataProduct variant
         Ok(Self {
             search: SearchParams {
-                // TODO: consider updating for regex field following [#66](https://github.com/Urban-Analytics-Technology-Platform/popgetter-cli/issues/66)
+                // TODO: consider defaults during implementing [#81](https://github.com/Urban-Analytics-Technology-Platform/popgetter-cli/issues/81)
                 text: value
                     .metrics
                     .iter()

--- a/src/data_request_spec.rs
+++ b/src/data_request_spec.rs
@@ -66,10 +66,11 @@ impl TryFrom<DataRequestSpec> for Params {
                 data_publisher: None,
                 country: None,
                 source_metric_id: None,
-                region_spec: value.region,
+                region_spec: value.region.clone(),
             },
             download: DownloadParams {
                 include_geoms: value.geometry.unwrap_or_default().include_geoms,
+                region_spec: value.region,
             },
         })
     }

--- a/src/data_request_spec.rs
+++ b/src/data_request_spec.rs
@@ -9,7 +9,7 @@ use crate::search::{GeometryLevel, MetricId, SearchParams, YearRange};
 
 #[derive(Serialize, Deserialize, Debug, Default)]
 pub struct DataRequestSpec {
-    pub geometry: GeometrySpec,
+    pub geometry: Option<GeometrySpec>,
     pub region: Vec<RegionSpec>,
     pub metrics: Vec<MetricSpec>,
     pub years: Option<Vec<String>>,
@@ -40,7 +40,9 @@ impl TryFrom<DataRequestSpec> for SearchParams {
                     }
                 })
                 .collect_vec(),
-            geometry_level: value.geometry.geometry_level.map(GeometryLevel),
+            geometry_level: value
+                .geometry
+                .and_then(|geometry| geometry.geometry_level.map(GeometryLevel)),
             source_data_release: None,
             data_publisher: None,
             country: None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,7 @@ impl Popgetter {
         search_params.search(&self.metadata.combined_metric_source_geometry())
     }
 
-    /// Downloads results using popgetter given `SearchResults`
+    /// Downloads data using popgetter given a `DataRequestSpec`
     pub async fn get_data_request(&self, data_request_spec: DataRequestSpec) -> Result<DataFrame> {
         let include_geoms = data_request_spec
             .geometry
@@ -60,7 +60,7 @@ impl Popgetter {
             .await
     }
 
-    /// Downloads results using popgetter given `SearchResults`
+    /// Downloads data using popgetter given `SearchParams`
     pub async fn get_search_params(
         &self,
         search_params: SearchParams,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,22 +49,21 @@ impl Popgetter {
     }
 
     /// Downloads data using popgetter given a `DataRequestSpec`
-    pub async fn get_data_request(&self, data_request_spec: DataRequestSpec) -> Result<DataFrame> {
-        let params: Params = data_request_spec.try_into()?;
+    pub async fn download_data_request_spec(
+        &self,
+        data_request_spec: &DataRequestSpec,
+    ) -> Result<DataFrame> {
+        let params: Params = data_request_spec.clone().try_into()?;
         let search_results = self.search(&params.search);
         search_results
             .download(&self.config, &params.download)
             .await
     }
 
-    /// Downloads data using popgetter given `SearchParams`
-    pub async fn get_search_params(
-        &self,
-        search_params: SearchParams,
-        download_params: DownloadParams,
-    ) -> Result<DataFrame> {
-        self.search(&search_params)
-            .download(&self.config, &download_params)
+    /// Downloads data using popgetter given `Params`
+    pub async fn download_params(&self, params: &Params) -> Result<DataFrame> {
+        self.search(&params.search)
+            .download(&self.config, &params.download)
             .await
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,14 +42,16 @@ impl Popgetter {
     }
 
     /// Generates `SearchResults` using popgetter given `SearchParams`
-    pub fn search(&self, search_params: SearchParams) -> SearchResults {
-        search_params.search(&self.metadata.combined_metric_source_geometry())
+    pub fn search(&self, search_params: &SearchParams) -> SearchResults {
+        search_params
+            .clone()
+            .search(&self.metadata.combined_metric_source_geometry())
     }
 
     /// Downloads data using popgetter given a `DataRequestSpec`
     pub async fn get_data_request(&self, data_request_spec: DataRequestSpec) -> Result<DataFrame> {
         let params: Params = data_request_spec.try_into()?;
-        let search_results = self.search(params.search.clone());
+        let search_results = self.search(&params.search);
         search_results
             .download(&self.config, &params.search, &params.download)
             .await
@@ -61,7 +63,7 @@ impl Popgetter {
         search_params: SearchParams,
         download_params: DownloadParams,
     ) -> Result<DataFrame> {
-        self.search(search_params.clone())
+        self.search(&search_params)
             .download(&self.config, &search_params, &download_params)
             .await
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@ use data_request_spec::DataRequestSpec;
 use log::debug;
 use metadata::Metadata;
 use polars::frame::DataFrame;
-use search::{SearchParams, SearchResults};
+use search::{DownloadParams, Params, SearchParams, SearchResults};
 
 use crate::config::Config;
 
@@ -48,15 +48,10 @@ impl Popgetter {
 
     /// Downloads data using popgetter given a `DataRequestSpec`
     pub async fn get_data_request(&self, data_request_spec: DataRequestSpec) -> Result<DataFrame> {
-        let include_geoms = data_request_spec
-            .geometry
-            .as_ref()
-            .map(|geo| geo.include_geoms)
-            .unwrap_or(true);
-        let search_params: SearchParams = data_request_spec.try_into()?;
-        let search_results = self.search(search_params.clone());
+        let params: Params = data_request_spec.try_into()?;
+        let search_results = self.search(params.search.clone());
         search_results
-            .download(&self.config, &search_params, include_geoms)
+            .download(&self.config, &params.search, &params.download)
             .await
     }
 
@@ -64,10 +59,10 @@ impl Popgetter {
     pub async fn get_search_params(
         &self,
         search_params: SearchParams,
-        include_geoms: bool,
+        download_params: DownloadParams,
     ) -> Result<DataFrame> {
         self.search(search_params.clone())
-            .download(&self.config, &search_params, include_geoms)
+            .download(&self.config, &search_params, &download_params)
             .await
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,7 @@ impl Popgetter {
         let params: Params = data_request_spec.try_into()?;
         let search_results = self.search(&params.search);
         search_results
-            .download(&self.config, &params.search, &params.download)
+            .download(&self.config, &params.download)
             .await
     }
 
@@ -64,7 +64,7 @@ impl Popgetter {
         download_params: DownloadParams,
     ) -> Result<DataFrame> {
         self.search(&search_params)
-            .download(&self.config, &search_params, &download_params)
+            .download(&self.config, &download_params)
             .await
     }
 }

--- a/src/search.rs
+++ b/src/search.rs
@@ -272,12 +272,17 @@ pub struct SourceMetricId(pub String);
 /// This struct represents all the possible parameters one can search the metadata catalogue with.
 /// All parameters are optional in that they can either be empty vectors or None.
 ///
-/// Each of the fields are combined with an AND operation, so searching for both text and a year
-/// range will only return metrics that satisfy both parameters.
+/// Aside from `metric_id`, each of the fields are combined with an AND operation, so searching for
+/// both text and a year range will only return metrics that satisfy both parameters.
 ///
 /// However, if a parameter has multiple values (e.g. multiple text strings), these are combined
 /// with an OR operation. So searching for multiple text strings will return metrics that satisfy
 /// any of the text strings.
+///
+/// `metric_id` is considered distinctly since the list of values uniquely identifies a set of
+/// metrics. This list of metrics is combined with the final combined expression of the other fields
+/// with an OR operation. This enables a search or recipe to contain a combination of specific
+/// `metric_id`s and other fields.
 #[derive(Clone, Debug, Deserialize, Serialize, Default)]
 pub struct SearchParams {
     pub text: Vec<SearchText>,

--- a/src/search.rs
+++ b/src/search.rs
@@ -412,7 +412,7 @@ impl SearchResults {
         // TODO Handle multiple geometries
         if all_geom_files.len() > 1 {
             unimplemented!("Multiple geometries not supported in current release");
-        } else if all_geom_files.len() == 0 {
+        } else if all_geom_files.is_empty() {
             bail!(
                 "No geometry files for the following `metric_requests`: {:#?}",
                 metric_requests

--- a/test_recipe.json
+++ b/test_recipe.json
@@ -1,23 +1,26 @@
 {
   "region": [
     {
-      "BoundingBox": [
-        -74.251785,
-        40.647043,
-        -73.673286,
-        40.91014
-      ]
+      "BoundingBox": [-74.251785, 40.647043, -73.673286, 40.91014]
     }
   ],
   "metrics": [
     {
-      "Metric": "f29c1976"
+      "MetricId": "f29c1976"
     },
     {
-      "Metric": "079f3ba3"
+      "MetricId": "079f3ba3"
     },
     {
-      "Metric": "81cae95d"
+      "MetricId": "81cae95d"
+    },
+    {
+      "MetricText": "Key: uniqueID, Value: B01001_001;"
     }
-  ]
+  ],
+  "years": ["2021"],
+  "geometry": {
+    "geometry_level": "tract",
+    "include_geoms": true
+  }
 }

--- a/test_recipe.json
+++ b/test_recipe.json
@@ -11,10 +11,13 @@
   ],
   "metrics": [
     {
-      "NamedMetric": "B01001_E002"
+      "Metric": "f29c1976"
     },
     {
-      "NamedMetric": "B01001_E001"
+      "Metric": "079f3ba3"
+    },
+    {
+      "Metric": "81cae95d"
     }
   ]
 }


### PR DESCRIPTION
Closes #67.

Reimplementation of recipe subcommand with the following approach:
- [x] Reintroduce and revise `DataRequestSpec` to enable use of previous recipes.
- [x] Revise types in metric specification to be either `MetricId` or `MetricText` combinable in search with logical `OR`.
- [x] Implement `TryFrom<DataRequestSpec> for SearchParams` to enable search/download with same API
- [x] Add `fn write_output` to reduce repetition
- [x] Add `BBox` to search params (also towards #66)
- [ ] ~~Enable recipe command to use the either `DataRequestSpec` or `SearchParams`~~ (this is an enhancement, so will open in a new issue)
